### PR TITLE
Add online offset fetching system for dynamic offset updates

### DIFF
--- a/Kenshi-Online/Game/OnlineOffsetProvider.cs
+++ b/Kenshi-Online/Game/OnlineOffsetProvider.cs
@@ -1,0 +1,883 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace KenshiMultiplayer.Game
+{
+    /// <summary>
+    /// Provides online offset fetching capabilities for Kenshi game memory addresses.
+    /// Supports multiple offset sources with fallback chain: Online -> Cache -> Hardcoded
+    /// </summary>
+    public class OnlineOffsetProvider
+    {
+        private static readonly HttpClient _httpClient = new HttpClient
+        {
+            Timeout = TimeSpan.FromSeconds(10)
+        };
+
+        private static OnlineOffsetProvider? _instance;
+        public static OnlineOffsetProvider Instance => _instance ??= new OnlineOffsetProvider();
+
+        // Default offset server URLs (can be configured)
+        private readonly List<string> _offsetServers = new()
+        {
+            "https://raw.githubusercontent.com/The404Studios/Kenshi-Online/main/offsets/kenshi_offsets.json",
+            "https://kenshi-online.the404studios.com/api/offsets",
+            "https://pastebin.com/raw/PLACEHOLDER" // Backup pastebin URL
+        };
+
+        private const string CACHE_FILE = "kenshi_offsets_cache.json";
+        private const string VERSION_FILE = "kenshi_version.txt";
+
+        private OnlineOffsetDatabase? _cachedOffsets;
+        private bool _isInitialized;
+
+        /// <summary>
+        /// Event fired when offsets are successfully loaded
+        /// </summary>
+        public event Action<OnlineOffsetDatabase>? OnOffsetsLoaded;
+
+        /// <summary>
+        /// Event fired when offset loading fails
+        /// </summary>
+        public event Action<string>? OnOffsetLoadFailed;
+
+        /// <summary>
+        /// Initialize the offset provider and attempt to fetch offsets
+        /// </summary>
+        public async Task<bool> InitializeAsync(string? gameVersion = null)
+        {
+            if (_isInitialized && _cachedOffsets != null)
+                return true;
+
+            gameVersion ??= DetectGameVersion();
+
+            // Try loading in order: Online -> Cache -> Hardcoded
+            _cachedOffsets = await TryLoadOffsetsAsync(gameVersion);
+
+            if (_cachedOffsets != null)
+            {
+                ApplyOffsetsToKenshiMemory(_cachedOffsets);
+                _isInitialized = true;
+                OnOffsetsLoaded?.Invoke(_cachedOffsets);
+                return true;
+            }
+
+            // Fall back to hardcoded offsets
+            Console.WriteLine("[OffsetProvider] All sources failed, using hardcoded offsets");
+            OnOffsetLoadFailed?.Invoke("All offset sources failed, using hardcoded fallback");
+            return false;
+        }
+
+        /// <summary>
+        /// Synchronous initialization wrapper
+        /// </summary>
+        public bool Initialize(string? gameVersion = null)
+        {
+            return InitializeAsync(gameVersion).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Try to load offsets from available sources
+        /// </summary>
+        private async Task<OnlineOffsetDatabase?> TryLoadOffsetsAsync(string gameVersion)
+        {
+            // 1. Try online sources
+            foreach (var server in _offsetServers)
+            {
+                try
+                {
+                    var offsets = await FetchOffsetsFromUrlAsync(server, gameVersion);
+                    if (offsets != null && ValidateOffsets(offsets))
+                    {
+                        Console.WriteLine($"[OffsetProvider] Successfully loaded offsets from: {server}");
+                        await SaveToCacheAsync(offsets);
+                        return offsets;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"[OffsetProvider] Failed to fetch from {server}: {ex.Message}");
+                }
+            }
+
+            // 2. Try local cache
+            var cached = await LoadFromCacheAsync();
+            if (cached != null && (cached.GameVersion == gameVersion || cached.IsUniversal))
+            {
+                Console.WriteLine("[OffsetProvider] Loaded offsets from local cache");
+                return cached;
+            }
+
+            // 3. Return null to trigger hardcoded fallback
+            return null;
+        }
+
+        /// <summary>
+        /// Fetch offsets from a URL
+        /// </summary>
+        private async Task<OnlineOffsetDatabase?> FetchOffsetsFromUrlAsync(string url, string gameVersion)
+        {
+            // Add version parameter if URL supports it
+            var requestUrl = url.Contains("?") ? $"{url}&version={gameVersion}" : $"{url}?version={gameVersion}";
+
+            try
+            {
+                var response = await _httpClient.GetStringAsync(requestUrl);
+                var database = JsonSerializer.Deserialize<OnlineOffsetDatabase>(response, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                });
+
+                return database;
+            }
+            catch (HttpRequestException)
+            {
+                // Try without version parameter
+                var response = await _httpClient.GetStringAsync(url);
+                return JsonSerializer.Deserialize<OnlineOffsetDatabase>(response, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                });
+            }
+        }
+
+        /// <summary>
+        /// Validate downloaded offsets
+        /// </summary>
+        private bool ValidateOffsets(OnlineOffsetDatabase offsets)
+        {
+            // Basic validation
+            if (offsets == null) return false;
+            if (string.IsNullOrEmpty(offsets.GameVersion) && !offsets.IsUniversal) return false;
+            if (offsets.GameOffsets == null) return false;
+
+            // Verify checksum if provided
+            if (!string.IsNullOrEmpty(offsets.Checksum))
+            {
+                var calculated = CalculateChecksum(offsets);
+                if (calculated != offsets.Checksum)
+                {
+                    Console.WriteLine("[OffsetProvider] Checksum mismatch!");
+                    return false;
+                }
+            }
+
+            // Verify minimum required offsets exist
+            if (offsets.GameOffsets.WorldInstance == 0 &&
+                offsets.GameOffsets.PlayerSquadList == 0 &&
+                offsets.GameOffsets.AllCharactersList == 0)
+            {
+                Console.WriteLine("[OffsetProvider] Missing critical offsets");
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Calculate checksum for validation
+        /// </summary>
+        private string CalculateChecksum(OnlineOffsetDatabase offsets)
+        {
+            var data = JsonSerializer.Serialize(offsets.GameOffsets);
+            using var sha256 = SHA256.Create();
+            var hash = sha256.ComputeHash(Encoding.UTF8.GetBytes(data));
+            return Convert.ToHexString(hash).ToLower();
+        }
+
+        /// <summary>
+        /// Save offsets to local cache
+        /// </summary>
+        private async Task SaveToCacheAsync(OnlineOffsetDatabase offsets)
+        {
+            try
+            {
+                offsets.CachedAt = DateTime.UtcNow;
+                var json = JsonSerializer.Serialize(offsets, new JsonSerializerOptions
+                {
+                    WriteIndented = true
+                });
+                await File.WriteAllTextAsync(CACHE_FILE, json);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[OffsetProvider] Failed to save cache: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Load offsets from local cache
+        /// </summary>
+        private async Task<OnlineOffsetDatabase?> LoadFromCacheAsync()
+        {
+            try
+            {
+                if (!File.Exists(CACHE_FILE))
+                    return null;
+
+                var json = await File.ReadAllTextAsync(CACHE_FILE);
+                var cached = JsonSerializer.Deserialize<OnlineOffsetDatabase>(json, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                });
+
+                // Check if cache is too old (7 days)
+                if (cached?.CachedAt != null && (DateTime.UtcNow - cached.CachedAt.Value).TotalDays > 7)
+                {
+                    Console.WriteLine("[OffsetProvider] Cache is stale (>7 days old)");
+                    return null;
+                }
+
+                return cached;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Apply loaded offsets to KenshiMemory static class
+        /// </summary>
+        private void ApplyOffsetsToKenshiMemory(OnlineOffsetDatabase database)
+        {
+            var offsets = database.GameOffsets;
+            if (offsets == null) return;
+
+            // Update base address
+            if (offsets.BaseAddress != 0)
+                KenshiMemory.BaseAddress = offsets.BaseAddress;
+
+            // The actual offset values will be used by creating a new accessor
+            // Since KenshiMemory uses const values, we provide runtime accessors
+            Console.WriteLine($"[OffsetProvider] Applied offsets for Kenshi {database.GameVersion}");
+            Console.WriteLine($"  - WorldInstance: 0x{offsets.WorldInstance:X}");
+            Console.WriteLine($"  - PlayerSquadList: 0x{offsets.PlayerSquadList:X}");
+            Console.WriteLine($"  - AllCharactersList: 0x{offsets.AllCharactersList:X}");
+        }
+
+        /// <summary>
+        /// Detect the game version from executable
+        /// </summary>
+        private string DetectGameVersion()
+        {
+            try
+            {
+                // Try to read from cached version file
+                if (File.Exists(VERSION_FILE))
+                {
+                    return File.ReadAllText(VERSION_FILE).Trim();
+                }
+
+                // Default to latest known version
+                return "1.0.64";
+            }
+            catch
+            {
+                return "1.0.64";
+            }
+        }
+
+        /// <summary>
+        /// Get current offsets (returns cached or hardcoded)
+        /// </summary>
+        public GameOffsetsData GetCurrentOffsets()
+        {
+            if (_cachedOffsets?.GameOffsets != null)
+                return _cachedOffsets.GameOffsets;
+
+            // Return hardcoded defaults
+            return GameOffsetsData.CreateHardcodedDefaults();
+        }
+
+        /// <summary>
+        /// Force refresh offsets from online
+        /// </summary>
+        public async Task<bool> RefreshOffsetsAsync()
+        {
+            _isInitialized = false;
+            _cachedOffsets = null;
+
+            // Delete cache to force re-fetch
+            try { File.Delete(CACHE_FILE); } catch { }
+
+            return await InitializeAsync();
+        }
+
+        /// <summary>
+        /// Add a custom offset server URL
+        /// </summary>
+        public void AddOffsetServer(string url)
+        {
+            if (!_offsetServers.Contains(url))
+                _offsetServers.Insert(0, url);
+        }
+
+        /// <summary>
+        /// Clear all offset servers and set a single source
+        /// </summary>
+        public void SetOffsetServer(string url)
+        {
+            _offsetServers.Clear();
+            _offsetServers.Add(url);
+        }
+    }
+
+    #region Data Models
+
+    /// <summary>
+    /// Online offset database structure
+    /// </summary>
+    public class OnlineOffsetDatabase
+    {
+        [JsonPropertyName("version")]
+        public int SchemaVersion { get; set; } = 1;
+
+        [JsonPropertyName("gameVersion")]
+        public string GameVersion { get; set; } = "";
+
+        [JsonPropertyName("isUniversal")]
+        public bool IsUniversal { get; set; }
+
+        [JsonPropertyName("lastUpdated")]
+        public DateTime LastUpdated { get; set; }
+
+        [JsonPropertyName("checksum")]
+        public string? Checksum { get; set; }
+
+        [JsonPropertyName("author")]
+        public string? Author { get; set; }
+
+        [JsonPropertyName("notes")]
+        public string? Notes { get; set; }
+
+        [JsonPropertyName("offsets")]
+        public GameOffsetsData? GameOffsets { get; set; }
+
+        [JsonPropertyName("patterns")]
+        public PatternSignaturesData? Patterns { get; set; }
+
+        [JsonPropertyName("structureOffsets")]
+        public StructureOffsetsData? StructureOffsets { get; set; }
+
+        [JsonPropertyName("functionOffsets")]
+        public FunctionOffsetsData? FunctionOffsets { get; set; }
+
+        // Internal use
+        [JsonIgnore]
+        public DateTime? CachedAt { get; set; }
+    }
+
+    /// <summary>
+    /// Core game pointer offsets
+    /// </summary>
+    public class GameOffsetsData
+    {
+        [JsonPropertyName("baseAddress")]
+        public long BaseAddress { get; set; }
+
+        // Game Core
+        [JsonPropertyName("worldInstance")]
+        public long WorldInstance { get; set; }
+
+        [JsonPropertyName("gameState")]
+        public long GameState { get; set; }
+
+        [JsonPropertyName("gameTime")]
+        public long GameTime { get; set; }
+
+        [JsonPropertyName("gameDay")]
+        public long GameDay { get; set; }
+
+        // Characters
+        [JsonPropertyName("playerSquadList")]
+        public long PlayerSquadList { get; set; }
+
+        [JsonPropertyName("playerSquadCount")]
+        public long PlayerSquadCount { get; set; }
+
+        [JsonPropertyName("allCharactersList")]
+        public long AllCharactersList { get; set; }
+
+        [JsonPropertyName("allCharactersCount")]
+        public long AllCharactersCount { get; set; }
+
+        [JsonPropertyName("selectedCharacter")]
+        public long SelectedCharacter { get; set; }
+
+        // Factions
+        [JsonPropertyName("factionList")]
+        public long FactionList { get; set; }
+
+        [JsonPropertyName("factionCount")]
+        public long FactionCount { get; set; }
+
+        [JsonPropertyName("playerFaction")]
+        public long PlayerFaction { get; set; }
+
+        [JsonPropertyName("relationMatrix")]
+        public long RelationMatrix { get; set; }
+
+        // World
+        [JsonPropertyName("buildingList")]
+        public long BuildingList { get; set; }
+
+        [JsonPropertyName("buildingCount")]
+        public long BuildingCount { get; set; }
+
+        [JsonPropertyName("worldItemsList")]
+        public long WorldItemsList { get; set; }
+
+        [JsonPropertyName("worldItemsCount")]
+        public long WorldItemsCount { get; set; }
+
+        [JsonPropertyName("weatherSystem")]
+        public long WeatherSystem { get; set; }
+
+        // Engine
+        [JsonPropertyName("physicsWorld")]
+        public long PhysicsWorld { get; set; }
+
+        [JsonPropertyName("camera")]
+        public long Camera { get; set; }
+
+        [JsonPropertyName("cameraTarget")]
+        public long CameraTarget { get; set; }
+
+        [JsonPropertyName("renderer")]
+        public long Renderer { get; set; }
+
+        // Input
+        [JsonPropertyName("inputHandler")]
+        public long InputHandler { get; set; }
+
+        [JsonPropertyName("commandQueue")]
+        public long CommandQueue { get; set; }
+
+        [JsonPropertyName("selectedUnits")]
+        public long SelectedUnits { get; set; }
+
+        [JsonPropertyName("uiState")]
+        public long UIState { get; set; }
+
+        public static GameOffsetsData CreateHardcodedDefaults()
+        {
+            return new GameOffsetsData
+            {
+                BaseAddress = 0x140000000,
+                WorldInstance = 0x24D8F40,
+                GameState = 0x24D8F48,
+                GameTime = 0x24D8F50,
+                GameDay = 0x24D8F58,
+                PlayerSquadList = 0x24C5A20,
+                PlayerSquadCount = 0x24C5A28,
+                AllCharactersList = 0x24C5B00,
+                AllCharactersCount = 0x24C5B08,
+                SelectedCharacter = 0x24C5A30,
+                FactionList = 0x24D2100,
+                FactionCount = 0x24D2108,
+                PlayerFaction = 0x24D2110,
+                RelationMatrix = 0x24D2200,
+                BuildingList = 0x24E1000,
+                BuildingCount = 0x24E1008,
+                WorldItemsList = 0x24E1100,
+                WorldItemsCount = 0x24E1108,
+                WeatherSystem = 0x24E7000,
+                PhysicsWorld = 0x24F0000,
+                Camera = 0x24E7C20,
+                CameraTarget = 0x24E7C38,
+                Renderer = 0x24F5000,
+                InputHandler = 0x24F2D80,
+                CommandQueue = 0x24F2D90,
+                SelectedUnits = 0x24F2DA0,
+                UIState = 0x24F3000
+            };
+        }
+    }
+
+    /// <summary>
+    /// Function address offsets
+    /// </summary>
+    public class FunctionOffsetsData
+    {
+        [JsonPropertyName("spawnCharacter")]
+        public long SpawnCharacter { get; set; }
+
+        [JsonPropertyName("despawnCharacter")]
+        public long DespawnCharacter { get; set; }
+
+        [JsonPropertyName("addToSquad")]
+        public long AddToSquad { get; set; }
+
+        [JsonPropertyName("removeFromSquad")]
+        public long RemoveFromSquad { get; set; }
+
+        [JsonPropertyName("addItemToInventory")]
+        public long AddItemToInventory { get; set; }
+
+        [JsonPropertyName("removeItemFromInventory")]
+        public long RemoveItemFromInventory { get; set; }
+
+        [JsonPropertyName("setCharacterState")]
+        public long SetCharacterState { get; set; }
+
+        [JsonPropertyName("issueCommand")]
+        public long IssueCommand { get; set; }
+
+        [JsonPropertyName("createFaction")]
+        public long CreateFaction { get; set; }
+
+        [JsonPropertyName("setFactionRelation")]
+        public long SetFactionRelation { get; set; }
+
+        [JsonPropertyName("pathfindRequest")]
+        public long PathfindRequest { get; set; }
+
+        [JsonPropertyName("combatAttack")]
+        public long CombatAttack { get; set; }
+
+        [JsonPropertyName("characterUpdate")]
+        public long CharacterUpdate { get; set; }
+
+        [JsonPropertyName("aiUpdate")]
+        public long AIUpdate { get; set; }
+
+        public static FunctionOffsetsData CreateHardcodedDefaults()
+        {
+            return new FunctionOffsetsData
+            {
+                SpawnCharacter = 0x8B3C80,
+                DespawnCharacter = 0x8B4120,
+                AddToSquad = 0x8B4500,
+                RemoveFromSquad = 0x8B4600,
+                AddItemToInventory = 0x9C2100,
+                RemoveItemFromInventory = 0x9C2200,
+                SetCharacterState = 0x8C1000,
+                IssueCommand = 0x8D5000,
+                CreateFaction = 0x7A2000,
+                SetFactionRelation = 0x7A2500,
+                PathfindRequest = 0x7B1000,
+                CombatAttack = 0x8E2000
+            };
+        }
+    }
+
+    /// <summary>
+    /// Character structure field offsets
+    /// </summary>
+    public class StructureOffsetsData
+    {
+        [JsonPropertyName("character")]
+        public CharacterStructureOffsets? Character { get; set; }
+
+        [JsonPropertyName("squad")]
+        public SquadStructureOffsets? Squad { get; set; }
+
+        [JsonPropertyName("faction")]
+        public FactionStructureOffsets? Faction { get; set; }
+
+        [JsonPropertyName("item")]
+        public ItemStructureOffsets? Item { get; set; }
+    }
+
+    public class CharacterStructureOffsets
+    {
+        [JsonPropertyName("position")]
+        public int Position { get; set; } = 0x70;
+
+        [JsonPropertyName("rotation")]
+        public int Rotation { get; set; } = 0x7C;
+
+        [JsonPropertyName("health")]
+        public int Health { get; set; } = 0xC0;
+
+        [JsonPropertyName("maxHealth")]
+        public int MaxHealth { get; set; } = 0xC4;
+
+        [JsonPropertyName("blood")]
+        public int Blood { get; set; } = 0xC8;
+
+        [JsonPropertyName("hunger")]
+        public int Hunger { get; set; } = 0xD0;
+
+        [JsonPropertyName("inventory")]
+        public int Inventory { get; set; } = 0xF0;
+
+        [JsonPropertyName("equipment")]
+        public int Equipment { get; set; } = 0xF8;
+
+        [JsonPropertyName("ai")]
+        public int AI { get; set; } = 0x110;
+
+        [JsonPropertyName("state")]
+        public int State { get; set; } = 0x118;
+
+        [JsonPropertyName("faction")]
+        public int Faction { get; set; } = 0x158;
+
+        [JsonPropertyName("squad")]
+        public int Squad { get; set; } = 0x168;
+
+        [JsonPropertyName("animState")]
+        public int AnimState { get; set; } = 0x140;
+
+        [JsonPropertyName("body")]
+        public int Body { get; set; } = 0xB8;
+    }
+
+    public class SquadStructureOffsets
+    {
+        [JsonPropertyName("members")]
+        public int Members { get; set; } = 0x20;
+
+        [JsonPropertyName("memberCount")]
+        public int MemberCount { get; set; } = 0x28;
+
+        [JsonPropertyName("leader")]
+        public int Leader { get; set; } = 0x30;
+
+        [JsonPropertyName("factionId")]
+        public int FactionId { get; set; } = 0x38;
+    }
+
+    public class FactionStructureOffsets
+    {
+        [JsonPropertyName("relations")]
+        public int Relations { get; set; } = 0x20;
+
+        [JsonPropertyName("members")]
+        public int Members { get; set; } = 0x30;
+
+        [JsonPropertyName("leader")]
+        public int Leader { get; set; } = 0x40;
+    }
+
+    public class ItemStructureOffsets
+    {
+        [JsonPropertyName("name")]
+        public int Name { get; set; } = 0x10;
+
+        [JsonPropertyName("category")]
+        public int Category { get; set; } = 0x18;
+
+        [JsonPropertyName("value")]
+        public int Value { get; set; } = 0x20;
+
+        [JsonPropertyName("weight")]
+        public int Weight { get; set; } = 0x24;
+
+        [JsonPropertyName("stackCount")]
+        public int StackCount { get; set; } = 0x28;
+    }
+
+    /// <summary>
+    /// Pattern signatures for dynamic scanning
+    /// </summary>
+    public class PatternSignaturesData
+    {
+        [JsonPropertyName("gameWorld")]
+        public PatternDefinition? GameWorld { get; set; }
+
+        [JsonPropertyName("playerSquadList")]
+        public PatternDefinition? PlayerSquadList { get; set; }
+
+        [JsonPropertyName("allCharactersList")]
+        public PatternDefinition? AllCharactersList { get; set; }
+
+        [JsonPropertyName("factionManager")]
+        public PatternDefinition? FactionManager { get; set; }
+
+        [JsonPropertyName("weatherSystem")]
+        public PatternDefinition? WeatherSystem { get; set; }
+
+        [JsonPropertyName("inputHandler")]
+        public PatternDefinition? InputHandler { get; set; }
+
+        [JsonPropertyName("cameraController")]
+        public PatternDefinition? CameraController { get; set; }
+
+        [JsonPropertyName("spawnCharacter")]
+        public PatternDefinition? SpawnCharacter { get; set; }
+
+        [JsonPropertyName("characterUpdate")]
+        public PatternDefinition? CharacterUpdate { get; set; }
+
+        [JsonPropertyName("combatSystem")]
+        public PatternDefinition? CombatSystem { get; set; }
+    }
+
+    public class PatternDefinition
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; } = "";
+
+        [JsonPropertyName("pattern")]
+        public string Pattern { get; set; } = "";
+
+        [JsonPropertyName("mask")]
+        public string Mask { get; set; } = "";
+
+        [JsonPropertyName("offset")]
+        public int Offset { get; set; }
+
+        [JsonPropertyName("isRelative")]
+        public bool IsRelative { get; set; }
+
+        [JsonPropertyName("relativeBase")]
+        public int RelativeBase { get; set; }
+    }
+
+    #endregion
+
+    #region Runtime Offset Accessor
+
+    /// <summary>
+    /// Runtime offset accessor that provides current offsets (online or hardcoded)
+    /// Use this instead of KenshiMemory.Game.* for runtime offset access
+    /// </summary>
+    public static class RuntimeOffsets
+    {
+        private static GameOffsetsData? _offsets;
+        private static FunctionOffsetsData? _functions;
+        private static StructureOffsetsData? _structures;
+
+        public static bool IsInitialized { get; private set; }
+
+        /// <summary>
+        /// Initialize runtime offsets from online provider
+        /// </summary>
+        public static async Task<bool> InitializeAsync()
+        {
+            var provider = OnlineOffsetProvider.Instance;
+            var success = await provider.InitializeAsync();
+
+            if (success)
+            {
+                var db = provider.GetCurrentOffsets();
+                _offsets = db;
+                _functions = FunctionOffsetsData.CreateHardcodedDefaults(); // TODO: Load from online
+                _structures = new StructureOffsetsData
+                {
+                    Character = new CharacterStructureOffsets()
+                };
+            }
+            else
+            {
+                // Use hardcoded defaults
+                _offsets = GameOffsetsData.CreateHardcodedDefaults();
+                _functions = FunctionOffsetsData.CreateHardcodedDefaults();
+                _structures = new StructureOffsetsData
+                {
+                    Character = new CharacterStructureOffsets()
+                };
+            }
+
+            IsInitialized = true;
+            return success;
+        }
+
+        /// <summary>
+        /// Synchronous initialization
+        /// </summary>
+        public static bool Initialize()
+        {
+            return InitializeAsync().GetAwaiter().GetResult();
+        }
+
+        // Accessors
+        public static long BaseAddress => _offsets?.BaseAddress ?? 0x140000000;
+
+        // Game Core
+        public static long WorldInstance => _offsets?.WorldInstance ?? KenshiMemory.Game.WorldInstance;
+        public static long GameState => _offsets?.GameState ?? KenshiMemory.Game.GameState;
+        public static long GameTime => _offsets?.GameTime ?? KenshiMemory.Game.GameTime;
+        public static long GameDay => _offsets?.GameDay ?? KenshiMemory.Game.GameDay;
+
+        // Characters
+        public static long PlayerSquadList => _offsets?.PlayerSquadList ?? KenshiMemory.Characters.PlayerSquadList;
+        public static long PlayerSquadCount => _offsets?.PlayerSquadCount ?? KenshiMemory.Characters.PlayerSquadCount;
+        public static long AllCharactersList => _offsets?.AllCharactersList ?? KenshiMemory.Characters.AllCharactersList;
+        public static long AllCharactersCount => _offsets?.AllCharactersCount ?? KenshiMemory.Characters.AllCharactersCount;
+        public static long SelectedCharacter => _offsets?.SelectedCharacter ?? KenshiMemory.Characters.SelectedCharacter;
+
+        // Factions
+        public static long FactionList => _offsets?.FactionList ?? KenshiMemory.Factions.FactionList;
+        public static long FactionCount => _offsets?.FactionCount ?? KenshiMemory.Factions.FactionCount;
+        public static long PlayerFaction => _offsets?.PlayerFaction ?? KenshiMemory.Factions.PlayerFaction;
+
+        // World
+        public static long BuildingList => _offsets?.BuildingList ?? KenshiMemory.World.BuildingList;
+        public static long BuildingCount => _offsets?.BuildingCount ?? KenshiMemory.World.BuildingCount;
+        public static long WeatherSystem => _offsets?.WeatherSystem ?? KenshiMemory.World.WeatherSystem;
+
+        // Engine
+        public static long PhysicsWorld => _offsets?.PhysicsWorld ?? KenshiMemory.Engine.PhysicsWorld;
+        public static long Camera => _offsets?.Camera ?? KenshiMemory.Engine.Camera;
+        public static long InputHandler => _offsets?.InputHandler ?? KenshiMemory.Input.InputHandler;
+
+        // Functions
+        public static long FnSpawnCharacter => _functions?.SpawnCharacter ?? KenshiMemory.Functions.SpawnCharacter;
+        public static long FnDespawnCharacter => _functions?.DespawnCharacter ?? KenshiMemory.Functions.DespawnCharacter;
+        public static long FnAddToSquad => _functions?.AddToSquad ?? KenshiMemory.Functions.AddToSquad;
+        public static long FnRemoveFromSquad => _functions?.RemoveFromSquad ?? KenshiMemory.Functions.RemoveFromSquad;
+        public static long FnAddItemToInventory => _functions?.AddItemToInventory ?? KenshiMemory.Functions.AddItemToInventory;
+        public static long FnRemoveItemFromInventory => _functions?.RemoveItemFromInventory ?? KenshiMemory.Functions.RemoveItemFromInventory;
+        public static long FnSetCharacterState => _functions?.SetCharacterState ?? KenshiMemory.Functions.SetCharacterState;
+        public static long FnIssueCommand => _functions?.IssueCommand ?? KenshiMemory.Functions.IssueCommand;
+        public static long FnSetFactionRelation => _functions?.SetFactionRelation ?? KenshiMemory.Functions.SetFactionRelation;
+        public static long FnPathfindRequest => _functions?.PathfindRequest ?? KenshiMemory.Functions.PathfindRequest;
+        public static long FnCombatAttack => _functions?.CombatAttack ?? KenshiMemory.Functions.CombatAttack;
+
+        // Character structure offsets
+        public static class Character
+        {
+            public static int Position => _structures?.Character?.Position ?? KenshiMemory.CharacterOffsets.Position;
+            public static int Rotation => _structures?.Character?.Rotation ?? KenshiMemory.CharacterOffsets.Rotation;
+            public static int Health => _structures?.Character?.Health ?? KenshiMemory.CharacterOffsets.Health;
+            public static int MaxHealth => _structures?.Character?.MaxHealth ?? KenshiMemory.CharacterOffsets.MaxHealth;
+            public static int Blood => _structures?.Character?.Blood ?? KenshiMemory.CharacterOffsets.Blood;
+            public static int Hunger => _structures?.Character?.Hunger ?? KenshiMemory.CharacterOffsets.Hunger;
+            public static int Inventory => _structures?.Character?.Inventory ?? KenshiMemory.CharacterOffsets.Inventory;
+            public static int Equipment => _structures?.Character?.Equipment ?? KenshiMemory.CharacterOffsets.Equipment;
+            public static int AI => _structures?.Character?.AI ?? KenshiMemory.CharacterOffsets.AI;
+            public static int State => _structures?.Character?.State ?? KenshiMemory.CharacterOffsets.State;
+            public static int Faction => _structures?.Character?.Faction ?? KenshiMemory.CharacterOffsets.Faction;
+            public static int Squad => _structures?.Character?.Squad ?? KenshiMemory.CharacterOffsets.Squad;
+            public static int AnimState => _structures?.Character?.AnimState ?? KenshiMemory.CharacterOffsets.AnimState;
+            public static int Body => _structures?.Character?.Body ?? KenshiMemory.CharacterOffsets.Body;
+        }
+
+        /// <summary>
+        /// Get absolute address (base + offset)
+        /// </summary>
+        public static long GetAbsolute(long offset) => BaseAddress + offset;
+
+        /// <summary>
+        /// Export current offsets as JSON
+        /// </summary>
+        public static string ExportAsJson()
+        {
+            var db = new OnlineOffsetDatabase
+            {
+                SchemaVersion = 1,
+                GameVersion = "1.0.64",
+                LastUpdated = DateTime.UtcNow,
+                IsUniversal = false,
+                GameOffsets = _offsets ?? GameOffsetsData.CreateHardcodedDefaults(),
+                FunctionOffsets = _functions ?? FunctionOffsetsData.CreateHardcodedDefaults(),
+                StructureOffsets = _structures ?? new StructureOffsetsData { Character = new CharacterStructureOffsets() }
+            };
+
+            return JsonSerializer.Serialize(db, new JsonSerializerOptions { WriteIndented = true });
+        }
+    }
+
+    #endregion
+}

--- a/KenshiOnlineMod/Memory/OnlineOffsetFetcher.cpp
+++ b/KenshiOnlineMod/Memory/OnlineOffsetFetcher.cpp
@@ -1,0 +1,936 @@
+/*
+ * Online Offset Fetcher Implementation
+ * Downloads and parses offset database from online sources
+ */
+
+#include "OnlineOffsetFetcher.h"
+#include "PatternScanner.h"
+#include <fstream>
+#include <sstream>
+#include <iomanip>
+#include <algorithm>
+#include <chrono>
+
+namespace Kenshi
+{
+    //=========================================================================
+    // ONLINE OFFSET FETCHER IMPLEMENTATION
+    //=========================================================================
+
+    OnlineOffsetFetcher::OnlineOffsetFetcher()
+    {
+        // Default server URLs
+        m_serverUrls = {
+            "https://raw.githubusercontent.com/The404Studios/Kenshi-Online/main/offsets/kenshi_offsets.json",
+            "https://kenshi-online.the404studios.com/api/offsets"
+        };
+    }
+
+    bool OnlineOffsetFetcher::Initialize(const std::string& customServerUrl)
+    {
+        if (!customServerUrl.empty())
+        {
+            AddServer(customServerUrl);
+        }
+
+        m_initialized = true;
+        return true;
+    }
+
+    bool OnlineOffsetFetcher::FetchOffsets(const std::string& gameVersion)
+    {
+        // Try to load from cache first
+        if (LoadCache())
+        {
+            // Validate cached version matches
+            if (m_database.isUniversal || m_database.gameVersion == gameVersion || gameVersion.empty())
+            {
+                if (m_loadCallback)
+                    m_loadCallback(true, "Loaded offsets from cache");
+                return true;
+            }
+        }
+
+        // Try each server
+        for (const auto& url : m_serverUrls)
+        {
+            std::string fetchUrl = url;
+            if (!gameVersion.empty() && url.find('?') == std::string::npos)
+            {
+                fetchUrl += "?version=" + gameVersion;
+            }
+
+            auto response = FetchUrl(fetchUrl);
+            if (response.has_value())
+            {
+                if (ParseJson(response.value()))
+                {
+                    if (ValidateOffsets())
+                    {
+                        m_database.isValid = true;
+                        SaveCache();
+
+                        if (m_loadCallback)
+                            m_loadCallback(true, "Loaded offsets from " + url);
+
+                        return true;
+                    }
+                }
+            }
+        }
+
+        if (m_loadCallback)
+            m_loadCallback(false, "Failed to fetch offsets from all sources");
+
+        return false;
+    }
+
+    std::optional<std::string> OnlineOffsetFetcher::FetchUrl(const std::string& url)
+    {
+        std::string result;
+
+        // Parse URL components
+        std::string host, path;
+        bool useHttps = false;
+        INTERNET_PORT port = INTERNET_DEFAULT_HTTP_PORT;
+
+        if (url.substr(0, 8) == "https://")
+        {
+            useHttps = true;
+            port = INTERNET_DEFAULT_HTTPS_PORT;
+            size_t pathStart = url.find('/', 8);
+            if (pathStart != std::string::npos)
+            {
+                host = url.substr(8, pathStart - 8);
+                path = url.substr(pathStart);
+            }
+            else
+            {
+                host = url.substr(8);
+                path = "/";
+            }
+        }
+        else if (url.substr(0, 7) == "http://")
+        {
+            size_t pathStart = url.find('/', 7);
+            if (pathStart != std::string::npos)
+            {
+                host = url.substr(7, pathStart - 7);
+                path = url.substr(pathStart);
+            }
+            else
+            {
+                host = url.substr(7);
+                path = "/";
+            }
+        }
+        else
+        {
+            return std::nullopt;
+        }
+
+        // Convert to wide strings
+        std::wstring wHost(host.begin(), host.end());
+        std::wstring wPath(path.begin(), path.end());
+
+        // Create session
+        HINTERNET hSession = WinHttpOpen(
+            L"KenshiOnline/1.0",
+            WINHTTP_ACCESS_TYPE_DEFAULT_PROXY,
+            WINHTTP_NO_PROXY_NAME,
+            WINHTTP_NO_PROXY_BYPASS,
+            0
+        );
+
+        if (!hSession)
+            return std::nullopt;
+
+        // Connect
+        HINTERNET hConnect = WinHttpConnect(hSession, wHost.c_str(), port, 0);
+        if (!hConnect)
+        {
+            WinHttpCloseHandle(hSession);
+            return std::nullopt;
+        }
+
+        // Create request
+        DWORD flags = useHttps ? WINHTTP_FLAG_SECURE : 0;
+        HINTERNET hRequest = WinHttpOpenRequest(
+            hConnect,
+            L"GET",
+            wPath.c_str(),
+            NULL,
+            WINHTTP_NO_REFERER,
+            WINHTTP_DEFAULT_ACCEPT_TYPES,
+            flags
+        );
+
+        if (!hRequest)
+        {
+            WinHttpCloseHandle(hConnect);
+            WinHttpCloseHandle(hSession);
+            return std::nullopt;
+        }
+
+        // Send request
+        BOOL bResults = WinHttpSendRequest(
+            hRequest,
+            WINHTTP_NO_ADDITIONAL_HEADERS,
+            0,
+            WINHTTP_NO_REQUEST_DATA,
+            0,
+            0,
+            0
+        );
+
+        if (bResults)
+        {
+            bResults = WinHttpReceiveResponse(hRequest, NULL);
+        }
+
+        if (bResults)
+        {
+            DWORD dwSize = 0;
+            DWORD dwDownloaded = 0;
+
+            do
+            {
+                dwSize = 0;
+                if (!WinHttpQueryDataAvailable(hRequest, &dwSize))
+                    break;
+
+                if (dwSize == 0)
+                    break;
+
+                std::vector<char> buffer(dwSize + 1, 0);
+
+                if (!WinHttpReadData(hRequest, buffer.data(), dwSize, &dwDownloaded))
+                    break;
+
+                result.append(buffer.data(), dwDownloaded);
+
+            } while (dwSize > 0);
+        }
+
+        // Cleanup
+        WinHttpCloseHandle(hRequest);
+        WinHttpCloseHandle(hConnect);
+        WinHttpCloseHandle(hSession);
+
+        if (result.empty())
+            return std::nullopt;
+
+        return result;
+    }
+
+    bool OnlineOffsetFetcher::ParseJson(const std::string& json)
+    {
+        // Extract metadata
+        m_database.schemaVersion = static_cast<int>(ExtractJsonNumber(json, "version"));
+        m_database.gameVersion = ExtractJsonValue(json, "gameVersion");
+        m_database.isUniversal = ExtractJsonBool(json, "isUniversal");
+        m_database.lastUpdated = ExtractJsonValue(json, "lastUpdated");
+        m_database.checksum = ExtractJsonValue(json, "checksum");
+        m_database.author = ExtractJsonValue(json, "author");
+        m_database.notes = ExtractJsonValue(json, "notes");
+
+        // Parse offsets
+        std::string offsetsJson = ExtractJsonObject(json, "offsets");
+        if (!offsetsJson.empty())
+        {
+            ParseGameOffsets(offsetsJson);
+        }
+
+        // Parse function offsets
+        std::string functionsJson = ExtractJsonObject(json, "functionOffsets");
+        if (!functionsJson.empty())
+        {
+            ParseFunctionOffsets(functionsJson);
+        }
+
+        // Parse structure offsets
+        std::string structuresJson = ExtractJsonObject(json, "structureOffsets");
+        if (!structuresJson.empty())
+        {
+            ParseStructureOffsets(structuresJson);
+        }
+
+        // Parse patterns
+        std::string patternsJson = ExtractJsonObject(json, "patterns");
+        if (!patternsJson.empty())
+        {
+            ParsePatterns(patternsJson);
+        }
+
+        return true;
+    }
+
+    bool OnlineOffsetFetcher::ParseGameOffsets(const std::string& json)
+    {
+        auto& o = m_database.gameOffsets;
+
+        o.baseAddress = static_cast<uint64_t>(ExtractJsonNumber(json, "baseAddress"));
+        o.worldInstance = static_cast<uint64_t>(ExtractJsonNumber(json, "worldInstance"));
+        o.gameState = static_cast<uint64_t>(ExtractJsonNumber(json, "gameState"));
+        o.gameTime = static_cast<uint64_t>(ExtractJsonNumber(json, "gameTime"));
+        o.gameDay = static_cast<uint64_t>(ExtractJsonNumber(json, "gameDay"));
+
+        o.playerSquadList = static_cast<uint64_t>(ExtractJsonNumber(json, "playerSquadList"));
+        o.playerSquadCount = static_cast<uint64_t>(ExtractJsonNumber(json, "playerSquadCount"));
+        o.allCharactersList = static_cast<uint64_t>(ExtractJsonNumber(json, "allCharactersList"));
+        o.allCharactersCount = static_cast<uint64_t>(ExtractJsonNumber(json, "allCharactersCount"));
+        o.selectedCharacter = static_cast<uint64_t>(ExtractJsonNumber(json, "selectedCharacter"));
+
+        o.factionList = static_cast<uint64_t>(ExtractJsonNumber(json, "factionList"));
+        o.factionCount = static_cast<uint64_t>(ExtractJsonNumber(json, "factionCount"));
+        o.playerFaction = static_cast<uint64_t>(ExtractJsonNumber(json, "playerFaction"));
+        o.relationMatrix = static_cast<uint64_t>(ExtractJsonNumber(json, "relationMatrix"));
+
+        o.buildingList = static_cast<uint64_t>(ExtractJsonNumber(json, "buildingList"));
+        o.buildingCount = static_cast<uint64_t>(ExtractJsonNumber(json, "buildingCount"));
+        o.worldItemsList = static_cast<uint64_t>(ExtractJsonNumber(json, "worldItemsList"));
+        o.worldItemsCount = static_cast<uint64_t>(ExtractJsonNumber(json, "worldItemsCount"));
+        o.weatherSystem = static_cast<uint64_t>(ExtractJsonNumber(json, "weatherSystem"));
+
+        o.physicsWorld = static_cast<uint64_t>(ExtractJsonNumber(json, "physicsWorld"));
+        o.camera = static_cast<uint64_t>(ExtractJsonNumber(json, "camera"));
+        o.cameraTarget = static_cast<uint64_t>(ExtractJsonNumber(json, "cameraTarget"));
+        o.renderer = static_cast<uint64_t>(ExtractJsonNumber(json, "renderer"));
+
+        o.inputHandler = static_cast<uint64_t>(ExtractJsonNumber(json, "inputHandler"));
+        o.commandQueue = static_cast<uint64_t>(ExtractJsonNumber(json, "commandQueue"));
+        o.selectedUnits = static_cast<uint64_t>(ExtractJsonNumber(json, "selectedUnits"));
+        o.uiState = static_cast<uint64_t>(ExtractJsonNumber(json, "uiState"));
+
+        return true;
+    }
+
+    bool OnlineOffsetFetcher::ParseFunctionOffsets(const std::string& json)
+    {
+        auto& f = m_database.functionOffsets;
+
+        f.spawnCharacter = static_cast<uint64_t>(ExtractJsonNumber(json, "spawnCharacter"));
+        f.despawnCharacter = static_cast<uint64_t>(ExtractJsonNumber(json, "despawnCharacter"));
+        f.addToSquad = static_cast<uint64_t>(ExtractJsonNumber(json, "addToSquad"));
+        f.removeFromSquad = static_cast<uint64_t>(ExtractJsonNumber(json, "removeFromSquad"));
+        f.addItemToInventory = static_cast<uint64_t>(ExtractJsonNumber(json, "addItemToInventory"));
+        f.removeItemFromInventory = static_cast<uint64_t>(ExtractJsonNumber(json, "removeItemFromInventory"));
+        f.setCharacterState = static_cast<uint64_t>(ExtractJsonNumber(json, "setCharacterState"));
+        f.issueCommand = static_cast<uint64_t>(ExtractJsonNumber(json, "issueCommand"));
+        f.createFaction = static_cast<uint64_t>(ExtractJsonNumber(json, "createFaction"));
+        f.setFactionRelation = static_cast<uint64_t>(ExtractJsonNumber(json, "setFactionRelation"));
+        f.pathfindRequest = static_cast<uint64_t>(ExtractJsonNumber(json, "pathfindRequest"));
+        f.combatAttack = static_cast<uint64_t>(ExtractJsonNumber(json, "combatAttack"));
+        f.characterUpdate = static_cast<uint64_t>(ExtractJsonNumber(json, "characterUpdate"));
+        f.aiUpdate = static_cast<uint64_t>(ExtractJsonNumber(json, "aiUpdate"));
+
+        return true;
+    }
+
+    bool OnlineOffsetFetcher::ParseStructureOffsets(const std::string& json)
+    {
+        auto& s = m_database.structureOffsets;
+
+        // Parse character offsets
+        std::string charJson = ExtractJsonObject(json, "character");
+        if (!charJson.empty())
+        {
+            s.charPosition = static_cast<int32_t>(ExtractJsonNumber(charJson, "position"));
+            s.charRotation = static_cast<int32_t>(ExtractJsonNumber(charJson, "rotation"));
+            s.charHealth = static_cast<int32_t>(ExtractJsonNumber(charJson, "health"));
+            s.charMaxHealth = static_cast<int32_t>(ExtractJsonNumber(charJson, "maxHealth"));
+            s.charBlood = static_cast<int32_t>(ExtractJsonNumber(charJson, "blood"));
+            s.charHunger = static_cast<int32_t>(ExtractJsonNumber(charJson, "hunger"));
+            s.charInventory = static_cast<int32_t>(ExtractJsonNumber(charJson, "inventory"));
+            s.charEquipment = static_cast<int32_t>(ExtractJsonNumber(charJson, "equipment"));
+            s.charAI = static_cast<int32_t>(ExtractJsonNumber(charJson, "ai"));
+            s.charState = static_cast<int32_t>(ExtractJsonNumber(charJson, "state"));
+            s.charFaction = static_cast<int32_t>(ExtractJsonNumber(charJson, "faction"));
+            s.charSquad = static_cast<int32_t>(ExtractJsonNumber(charJson, "squad"));
+            s.charAnimState = static_cast<int32_t>(ExtractJsonNumber(charJson, "animState"));
+            s.charBody = static_cast<int32_t>(ExtractJsonNumber(charJson, "body"));
+        }
+
+        // Parse squad offsets
+        std::string squadJson = ExtractJsonObject(json, "squad");
+        if (!squadJson.empty())
+        {
+            s.squadMembers = static_cast<int32_t>(ExtractJsonNumber(squadJson, "members"));
+            s.squadMemberCount = static_cast<int32_t>(ExtractJsonNumber(squadJson, "memberCount"));
+            s.squadLeader = static_cast<int32_t>(ExtractJsonNumber(squadJson, "leader"));
+            s.squadFactionId = static_cast<int32_t>(ExtractJsonNumber(squadJson, "factionId"));
+        }
+
+        // Parse faction offsets
+        std::string factionJson = ExtractJsonObject(json, "faction");
+        if (!factionJson.empty())
+        {
+            s.factionRelations = static_cast<int32_t>(ExtractJsonNumber(factionJson, "relations"));
+            s.factionMembers = static_cast<int32_t>(ExtractJsonNumber(factionJson, "members"));
+            s.factionLeader = static_cast<int32_t>(ExtractJsonNumber(factionJson, "leader"));
+        }
+
+        // Parse item offsets
+        std::string itemJson = ExtractJsonObject(json, "item");
+        if (!itemJson.empty())
+        {
+            s.itemName = static_cast<int32_t>(ExtractJsonNumber(itemJson, "name"));
+            s.itemCategory = static_cast<int32_t>(ExtractJsonNumber(itemJson, "category"));
+            s.itemValue = static_cast<int32_t>(ExtractJsonNumber(itemJson, "value"));
+            s.itemWeight = static_cast<int32_t>(ExtractJsonNumber(itemJson, "weight"));
+            s.itemStackCount = static_cast<int32_t>(ExtractJsonNumber(itemJson, "stackCount"));
+        }
+
+        return true;
+    }
+
+    bool OnlineOffsetFetcher::ParsePatterns(const std::string& json)
+    {
+        // Pattern names to look for
+        std::vector<std::string> patternNames = {
+            "gameWorld", "playerSquadList", "allCharactersList", "factionManager",
+            "weatherSystem", "inputHandler", "cameraController", "spawnCharacter",
+            "characterUpdate", "combatSystem"
+        };
+
+        for (const auto& name : patternNames)
+        {
+            std::string patternJson = ExtractJsonObject(json, name);
+            if (!patternJson.empty())
+            {
+                OnlinePatternDef def;
+                def.name = ExtractJsonValue(patternJson, "name");
+                def.pattern = ExtractJsonValue(patternJson, "pattern");
+                def.mask = ExtractJsonValue(patternJson, "mask");
+                def.offset = static_cast<int32_t>(ExtractJsonNumber(patternJson, "offset"));
+                def.isRelative = ExtractJsonBool(patternJson, "isRelative");
+                def.relativeBase = static_cast<int32_t>(ExtractJsonNumber(patternJson, "relativeBase"));
+
+                m_database.patterns[name] = def;
+            }
+        }
+
+        return true;
+    }
+
+    bool OnlineOffsetFetcher::ValidateOffsets()
+    {
+        const auto& o = m_database.gameOffsets;
+
+        // Check that we have at least some critical offsets
+        if (o.worldInstance == 0 && o.playerSquadList == 0 && o.allCharactersList == 0)
+        {
+            return false;
+        }
+
+        // TODO: Add checksum validation if checksum is provided
+        // if (!m_database.checksum.empty()) { ... }
+
+        return true;
+    }
+
+    bool OnlineOffsetFetcher::SaveCache(const std::string& filename)
+    {
+        std::ofstream file(filename, std::ios::binary);
+        if (!file.is_open())
+            return false;
+
+        // Write magic + version
+        uint32_t magic = 0x4B4F4646; // "KOFF"
+        uint32_t version = 1;
+        file.write(reinterpret_cast<char*>(&magic), sizeof(magic));
+        file.write(reinterpret_cast<char*>(&version), sizeof(version));
+
+        // Write timestamp
+        auto now = std::chrono::system_clock::now().time_since_epoch();
+        uint64_t timestamp = std::chrono::duration_cast<std::chrono::seconds>(now).count();
+        file.write(reinterpret_cast<char*>(&timestamp), sizeof(timestamp));
+
+        // Write game version string length + data
+        uint32_t versionLen = static_cast<uint32_t>(m_database.gameVersion.length());
+        file.write(reinterpret_cast<char*>(&versionLen), sizeof(versionLen));
+        file.write(m_database.gameVersion.c_str(), versionLen);
+
+        // Write offsets
+        file.write(reinterpret_cast<const char*>(&m_database.gameOffsets), sizeof(OnlineGameOffsets));
+        file.write(reinterpret_cast<const char*>(&m_database.functionOffsets), sizeof(OnlineFunctionOffsets));
+        file.write(reinterpret_cast<const char*>(&m_database.structureOffsets), sizeof(OnlineStructureOffsets));
+
+        file.close();
+        return true;
+    }
+
+    bool OnlineOffsetFetcher::LoadCache(const std::string& filename)
+    {
+        std::ifstream file(filename, std::ios::binary);
+        if (!file.is_open())
+            return false;
+
+        // Read and verify magic
+        uint32_t magic, version;
+        file.read(reinterpret_cast<char*>(&magic), sizeof(magic));
+        file.read(reinterpret_cast<char*>(&version), sizeof(version));
+
+        if (magic != 0x4B4F4646 || version != 1)
+            return false;
+
+        // Read timestamp and check if cache is too old (7 days)
+        uint64_t timestamp;
+        file.read(reinterpret_cast<char*>(&timestamp), sizeof(timestamp));
+
+        auto now = std::chrono::system_clock::now().time_since_epoch();
+        uint64_t nowTimestamp = std::chrono::duration_cast<std::chrono::seconds>(now).count();
+
+        if (nowTimestamp - timestamp > 7 * 24 * 60 * 60)
+        {
+            // Cache is too old
+            return false;
+        }
+
+        // Read game version
+        uint32_t versionLen;
+        file.read(reinterpret_cast<char*>(&versionLen), sizeof(versionLen));
+        if (versionLen > 64)
+            return false;
+
+        std::vector<char> versionBuf(versionLen + 1, 0);
+        file.read(versionBuf.data(), versionLen);
+        m_database.gameVersion = versionBuf.data();
+
+        // Read offsets
+        file.read(reinterpret_cast<char*>(&m_database.gameOffsets), sizeof(OnlineGameOffsets));
+        file.read(reinterpret_cast<char*>(&m_database.functionOffsets), sizeof(OnlineFunctionOffsets));
+        file.read(reinterpret_cast<char*>(&m_database.structureOffsets), sizeof(OnlineStructureOffsets));
+
+        m_database.isValid = true;
+        file.close();
+        return true;
+    }
+
+    bool OnlineOffsetFetcher::RefreshOffsets()
+    {
+        // Delete cache file
+        std::remove("kenshi_offsets_cache.dat");
+
+        m_database = OnlineOffsetDatabase();
+        return FetchOffsets();
+    }
+
+    void OnlineOffsetFetcher::AddServer(const std::string& url)
+    {
+        m_serverUrls.insert(m_serverUrls.begin(), url);
+    }
+
+    std::string OnlineOffsetFetcher::ExportAsJson() const
+    {
+        std::ostringstream json;
+        json << "{\n";
+        json << "  \"version\": " << m_database.schemaVersion << ",\n";
+        json << "  \"gameVersion\": \"" << m_database.gameVersion << "\",\n";
+        json << "  \"isUniversal\": " << (m_database.isUniversal ? "true" : "false") << ",\n";
+        json << "  \"offsets\": {\n";
+
+        const auto& o = m_database.gameOffsets;
+        json << "    \"baseAddress\": " << o.baseAddress << ",\n";
+        json << "    \"worldInstance\": " << o.worldInstance << ",\n";
+        json << "    \"playerSquadList\": " << o.playerSquadList << ",\n";
+        json << "    \"allCharactersList\": " << o.allCharactersList << "\n";
+        // ... (abbreviated for brevity)
+
+        json << "  }\n";
+        json << "}\n";
+
+        return json.str();
+    }
+
+    // JSON parsing helpers (simple implementation without external library)
+    std::string OnlineOffsetFetcher::ExtractJsonValue(const std::string& json, const std::string& key)
+    {
+        std::string searchKey = "\"" + key + "\"";
+        size_t keyPos = json.find(searchKey);
+        if (keyPos == std::string::npos)
+            return "";
+
+        size_t colonPos = json.find(':', keyPos);
+        if (colonPos == std::string::npos)
+            return "";
+
+        size_t valueStart = json.find_first_not_of(" \t\n\r", colonPos + 1);
+        if (valueStart == std::string::npos)
+            return "";
+
+        if (json[valueStart] == '"')
+        {
+            // String value
+            size_t valueEnd = json.find('"', valueStart + 1);
+            if (valueEnd == std::string::npos)
+                return "";
+            return json.substr(valueStart + 1, valueEnd - valueStart - 1);
+        }
+
+        return "";
+    }
+
+    int64_t OnlineOffsetFetcher::ExtractJsonNumber(const std::string& json, const std::string& key)
+    {
+        std::string searchKey = "\"" + key + "\"";
+        size_t keyPos = json.find(searchKey);
+        if (keyPos == std::string::npos)
+            return 0;
+
+        size_t colonPos = json.find(':', keyPos);
+        if (colonPos == std::string::npos)
+            return 0;
+
+        size_t valueStart = json.find_first_not_of(" \t\n\r", colonPos + 1);
+        if (valueStart == std::string::npos)
+            return 0;
+
+        // Check for hex format
+        if (json.substr(valueStart, 2) == "0x" || json.substr(valueStart, 2) == "0X")
+        {
+            return std::stoll(json.substr(valueStart), nullptr, 16);
+        }
+
+        // Decimal
+        size_t valueEnd = json.find_first_of(",}\n\r", valueStart);
+        std::string numStr = json.substr(valueStart, valueEnd - valueStart);
+
+        // Remove whitespace
+        numStr.erase(std::remove_if(numStr.begin(), numStr.end(), ::isspace), numStr.end());
+
+        try
+        {
+            return std::stoll(numStr);
+        }
+        catch (...)
+        {
+            return 0;
+        }
+    }
+
+    bool OnlineOffsetFetcher::ExtractJsonBool(const std::string& json, const std::string& key)
+    {
+        std::string searchKey = "\"" + key + "\"";
+        size_t keyPos = json.find(searchKey);
+        if (keyPos == std::string::npos)
+            return false;
+
+        size_t colonPos = json.find(':', keyPos);
+        if (colonPos == std::string::npos)
+            return false;
+
+        size_t valueStart = json.find_first_not_of(" \t\n\r", colonPos + 1);
+        if (valueStart == std::string::npos)
+            return false;
+
+        return json.substr(valueStart, 4) == "true";
+    }
+
+    std::string OnlineOffsetFetcher::ExtractJsonObject(const std::string& json, const std::string& key)
+    {
+        std::string searchKey = "\"" + key + "\"";
+        size_t keyPos = json.find(searchKey);
+        if (keyPos == std::string::npos)
+            return "";
+
+        size_t braceStart = json.find('{', keyPos);
+        if (braceStart == std::string::npos)
+            return "";
+
+        // Find matching closing brace
+        int braceCount = 1;
+        size_t braceEnd = braceStart + 1;
+        while (braceEnd < json.length() && braceCount > 0)
+        {
+            if (json[braceEnd] == '{')
+                braceCount++;
+            else if (json[braceEnd] == '}')
+                braceCount--;
+            braceEnd++;
+        }
+
+        if (braceCount != 0)
+            return "";
+
+        return json.substr(braceStart, braceEnd - braceStart);
+    }
+
+    std::string OnlineOffsetFetcher::ExtractJsonArray(const std::string& json, const std::string& key)
+    {
+        std::string searchKey = "\"" + key + "\"";
+        size_t keyPos = json.find(searchKey);
+        if (keyPos == std::string::npos)
+            return "";
+
+        size_t bracketStart = json.find('[', keyPos);
+        if (bracketStart == std::string::npos)
+            return "";
+
+        // Find matching closing bracket
+        int bracketCount = 1;
+        size_t bracketEnd = bracketStart + 1;
+        while (bracketEnd < json.length() && bracketCount > 0)
+        {
+            if (json[bracketEnd] == '[')
+                bracketCount++;
+            else if (json[bracketEnd] == ']')
+                bracketCount--;
+            bracketEnd++;
+        }
+
+        if (bracketCount != 0)
+            return "";
+
+        return json.substr(bracketStart, bracketEnd - bracketStart);
+    }
+
+    //=========================================================================
+    // INTEGRATED OFFSET MANAGER IMPLEMENTATION
+    //=========================================================================
+
+    bool IntegratedOffsetManager::Initialize(HMODULE gameModule)
+    {
+        if (m_initialized)
+            return true;
+
+        // Get module base
+        if (gameModule == nullptr)
+            gameModule = GetModuleHandle(NULL);
+
+        MODULEINFO moduleInfo;
+        if (GetModuleInformation(GetCurrentProcess(), gameModule, &moduleInfo, sizeof(moduleInfo)))
+        {
+            m_moduleBase = reinterpret_cast<uintptr_t>(moduleInfo.lpBaseOfDll);
+            m_moduleSize = moduleInfo.SizeOfImage;
+        }
+
+        // Priority 1: Try online offsets
+        if (m_preferOnline)
+        {
+            auto& fetcher = OnlineOffsetFetcher::Get();
+            fetcher.Initialize();
+
+            if (fetcher.FetchOffsets())
+            {
+                ApplyOnlineOffsets();
+                m_onlineLoaded = true;
+                m_currentSource = OffsetSource::Online;
+                m_initialized = true;
+                return true;
+            }
+        }
+
+        // Priority 2: Try pattern scanning
+        if (m_allowPatternScan)
+        {
+            auto& scanner = PatternScanner::Get();
+            if (scanner.Initialize(gameModule) && scanner.ScanAllSignatures())
+            {
+                ApplyPatternOffsets();
+                m_patternScanned = true;
+                m_currentSource = OffsetSource::PatternScan;
+                m_initialized = true;
+                return true;
+            }
+        }
+
+        // Priority 3: Use hardcoded offsets
+        ApplyHardcodedOffsets();
+        m_currentSource = OffsetSource::Hardcoded;
+        m_initialized = true;
+        return true;
+    }
+
+    uint64_t IntegratedOffsetManager::GetOffset(const std::string& category, const std::string& name) const
+    {
+        std::string key = category + "." + name;
+        auto it = m_offsets.find(key);
+        if (it != m_offsets.end())
+            return it->second;
+        return 0;
+    }
+
+    uint64_t IntegratedOffsetManager::GetAbsolute(const std::string& category, const std::string& name) const
+    {
+        return m_moduleBase + GetOffset(category, name);
+    }
+
+    uint64_t IntegratedOffsetManager::GetFunction(const std::string& name) const
+    {
+        auto it = m_functions.find(name);
+        if (it != m_functions.end())
+            return m_moduleBase + it->second;
+        return 0;
+    }
+
+    int32_t IntegratedOffsetManager::GetStructureOffset(const std::string& structure, const std::string& field) const
+    {
+        std::string key = structure + "." + field;
+        auto it = m_structureOffsets.find(key);
+        if (it != m_structureOffsets.end())
+            return it->second;
+        return 0;
+    }
+
+    void IntegratedOffsetManager::SetSourcePriority(bool preferOnline, bool allowPatternScan)
+    {
+        m_preferOnline = preferOnline;
+        m_allowPatternScan = allowPatternScan;
+    }
+
+    bool IntegratedOffsetManager::Reload()
+    {
+        m_initialized = false;
+        m_onlineLoaded = false;
+        m_patternScanned = false;
+        m_offsets.clear();
+        m_functions.clear();
+        m_structureOffsets.clear();
+
+        return Initialize(nullptr);
+    }
+
+    void IntegratedOffsetManager::ApplyOnlineOffsets()
+    {
+        const auto& db = OnlineOffsetFetcher::Get().GetDatabase();
+        const auto& o = db.gameOffsets;
+        const auto& f = db.functionOffsets;
+        const auto& s = db.structureOffsets;
+
+        // Game offsets
+        m_offsets["Game.WorldInstance"] = o.worldInstance;
+        m_offsets["Game.GameState"] = o.gameState;
+        m_offsets["Game.GameTime"] = o.gameTime;
+        m_offsets["Game.GameDay"] = o.gameDay;
+
+        m_offsets["Characters.PlayerSquadList"] = o.playerSquadList;
+        m_offsets["Characters.PlayerSquadCount"] = o.playerSquadCount;
+        m_offsets["Characters.AllCharactersList"] = o.allCharactersList;
+        m_offsets["Characters.AllCharactersCount"] = o.allCharactersCount;
+        m_offsets["Characters.SelectedCharacter"] = o.selectedCharacter;
+
+        m_offsets["Factions.FactionList"] = o.factionList;
+        m_offsets["Factions.FactionCount"] = o.factionCount;
+        m_offsets["Factions.PlayerFaction"] = o.playerFaction;
+
+        m_offsets["World.BuildingList"] = o.buildingList;
+        m_offsets["World.BuildingCount"] = o.buildingCount;
+        m_offsets["World.WeatherSystem"] = o.weatherSystem;
+
+        m_offsets["Engine.PhysicsWorld"] = o.physicsWorld;
+        m_offsets["Engine.Camera"] = o.camera;
+
+        m_offsets["Input.InputHandler"] = o.inputHandler;
+
+        // Function offsets
+        m_functions["SpawnCharacter"] = f.spawnCharacter;
+        m_functions["DespawnCharacter"] = f.despawnCharacter;
+        m_functions["AddToSquad"] = f.addToSquad;
+        m_functions["RemoveFromSquad"] = f.removeFromSquad;
+        m_functions["AddItemToInventory"] = f.addItemToInventory;
+        m_functions["RemoveItemFromInventory"] = f.removeItemFromInventory;
+        m_functions["SetCharacterState"] = f.setCharacterState;
+        m_functions["IssueCommand"] = f.issueCommand;
+        m_functions["SetFactionRelation"] = f.setFactionRelation;
+        m_functions["PathfindRequest"] = f.pathfindRequest;
+        m_functions["CombatAttack"] = f.combatAttack;
+
+        // Structure offsets
+        m_structureOffsets["Character.Position"] = s.charPosition;
+        m_structureOffsets["Character.Rotation"] = s.charRotation;
+        m_structureOffsets["Character.Health"] = s.charHealth;
+        m_structureOffsets["Character.MaxHealth"] = s.charMaxHealth;
+        m_structureOffsets["Character.Blood"] = s.charBlood;
+        m_structureOffsets["Character.Hunger"] = s.charHunger;
+        m_structureOffsets["Character.Inventory"] = s.charInventory;
+        m_structureOffsets["Character.Equipment"] = s.charEquipment;
+        m_structureOffsets["Character.AI"] = s.charAI;
+        m_structureOffsets["Character.State"] = s.charState;
+        m_structureOffsets["Character.Faction"] = s.charFaction;
+        m_structureOffsets["Character.Squad"] = s.charSquad;
+        m_structureOffsets["Character.AnimState"] = s.charAnimState;
+        m_structureOffsets["Character.Body"] = s.charBody;
+    }
+
+    void IntegratedOffsetManager::ApplyPatternOffsets()
+    {
+        auto& scanner = PatternScanner::Get();
+
+        // Get pattern-scanned addresses and convert to offsets
+        auto gameWorld = scanner.GetAddress("GameWorld");
+        if (gameWorld)
+            m_offsets["Game.WorldInstance"] = gameWorld - m_moduleBase;
+
+        auto playerSquad = scanner.GetAddress("PlayerSquadList");
+        if (playerSquad)
+            m_offsets["Characters.PlayerSquadList"] = playerSquad - m_moduleBase;
+
+        auto allChars = scanner.GetAddress("AllCharactersList");
+        if (allChars)
+            m_offsets["Characters.AllCharactersList"] = allChars - m_moduleBase;
+
+        // ... Add more pattern results
+
+        // For structure offsets, use defaults as patterns don't typically provide these
+        ApplyHardcodedOffsets();
+    }
+
+    void IntegratedOffsetManager::ApplyHardcodedOffsets()
+    {
+        // Kenshi v1.0.x 64-bit hardcoded offsets
+        m_offsets["Game.WorldInstance"] = 0x24D8F40;
+        m_offsets["Game.GameState"] = 0x24D8F48;
+        m_offsets["Game.GameTime"] = 0x24D8F50;
+        m_offsets["Game.GameDay"] = 0x24D8F58;
+
+        m_offsets["Characters.PlayerSquadList"] = 0x24C5A20;
+        m_offsets["Characters.PlayerSquadCount"] = 0x24C5A28;
+        m_offsets["Characters.AllCharactersList"] = 0x24C5B00;
+        m_offsets["Characters.AllCharactersCount"] = 0x24C5B08;
+        m_offsets["Characters.SelectedCharacter"] = 0x24C5A30;
+
+        m_offsets["Factions.FactionList"] = 0x24D2100;
+        m_offsets["Factions.FactionCount"] = 0x24D2108;
+        m_offsets["Factions.PlayerFaction"] = 0x24D2110;
+
+        m_offsets["World.BuildingList"] = 0x24E1000;
+        m_offsets["World.BuildingCount"] = 0x24E1008;
+        m_offsets["World.WeatherSystem"] = 0x24E7000;
+
+        m_offsets["Engine.PhysicsWorld"] = 0x24F0000;
+        m_offsets["Engine.Camera"] = 0x24E7C20;
+
+        m_offsets["Input.InputHandler"] = 0x24F2D80;
+
+        // Functions
+        m_functions["SpawnCharacter"] = 0x8B3C80;
+        m_functions["DespawnCharacter"] = 0x8B4120;
+        m_functions["AddToSquad"] = 0x8B4500;
+        m_functions["RemoveFromSquad"] = 0x8B4600;
+        m_functions["AddItemToInventory"] = 0x9C2100;
+        m_functions["RemoveItemFromInventory"] = 0x9C2200;
+        m_functions["SetCharacterState"] = 0x8C1000;
+        m_functions["IssueCommand"] = 0x8D5000;
+        m_functions["SetFactionRelation"] = 0x7A2500;
+        m_functions["PathfindRequest"] = 0x7B1000;
+        m_functions["CombatAttack"] = 0x8E2000;
+
+        // Structure offsets
+        m_structureOffsets["Character.Position"] = 0x70;
+        m_structureOffsets["Character.Rotation"] = 0x7C;
+        m_structureOffsets["Character.Health"] = 0xC0;
+        m_structureOffsets["Character.MaxHealth"] = 0xC4;
+        m_structureOffsets["Character.Blood"] = 0xC8;
+        m_structureOffsets["Character.Hunger"] = 0xD0;
+        m_structureOffsets["Character.Inventory"] = 0xF0;
+        m_structureOffsets["Character.Equipment"] = 0xF8;
+        m_structureOffsets["Character.AI"] = 0x110;
+        m_structureOffsets["Character.State"] = 0x118;
+        m_structureOffsets["Character.Faction"] = 0x158;
+        m_structureOffsets["Character.Squad"] = 0x168;
+        m_structureOffsets["Character.AnimState"] = 0x140;
+        m_structureOffsets["Character.Body"] = 0xB8;
+    }
+
+} // namespace Kenshi

--- a/KenshiOnlineMod/Memory/OnlineOffsetFetcher.h
+++ b/KenshiOnlineMod/Memory/OnlineOffsetFetcher.h
@@ -1,0 +1,317 @@
+/*
+ * Online Offset Fetcher for Kenshi
+ * Downloads offset database from online sources for dynamic configuration
+ * Supports multiple fallback servers and local caching
+ */
+
+#pragma once
+
+#include <Windows.h>
+#include <winhttp.h>
+#include <cstdint>
+#include <string>
+#include <vector>
+#include <unordered_map>
+#include <functional>
+#include <optional>
+
+#pragma comment(lib, "winhttp.lib")
+
+namespace Kenshi
+{
+    //=========================================================================
+    // ONLINE OFFSET DATA STRUCTURES
+    //=========================================================================
+
+    struct OnlineGameOffsets
+    {
+        // Base
+        uint64_t baseAddress = 0x140000000;
+
+        // Game Core
+        uint64_t worldInstance = 0;
+        uint64_t gameState = 0;
+        uint64_t gameTime = 0;
+        uint64_t gameDay = 0;
+
+        // Characters
+        uint64_t playerSquadList = 0;
+        uint64_t playerSquadCount = 0;
+        uint64_t allCharactersList = 0;
+        uint64_t allCharactersCount = 0;
+        uint64_t selectedCharacter = 0;
+
+        // Factions
+        uint64_t factionList = 0;
+        uint64_t factionCount = 0;
+        uint64_t playerFaction = 0;
+        uint64_t relationMatrix = 0;
+
+        // World
+        uint64_t buildingList = 0;
+        uint64_t buildingCount = 0;
+        uint64_t worldItemsList = 0;
+        uint64_t worldItemsCount = 0;
+        uint64_t weatherSystem = 0;
+
+        // Engine
+        uint64_t physicsWorld = 0;
+        uint64_t camera = 0;
+        uint64_t cameraTarget = 0;
+        uint64_t renderer = 0;
+
+        // Input
+        uint64_t inputHandler = 0;
+        uint64_t commandQueue = 0;
+        uint64_t selectedUnits = 0;
+        uint64_t uiState = 0;
+    };
+
+    struct OnlineFunctionOffsets
+    {
+        uint64_t spawnCharacter = 0;
+        uint64_t despawnCharacter = 0;
+        uint64_t addToSquad = 0;
+        uint64_t removeFromSquad = 0;
+        uint64_t addItemToInventory = 0;
+        uint64_t removeItemFromInventory = 0;
+        uint64_t setCharacterState = 0;
+        uint64_t issueCommand = 0;
+        uint64_t createFaction = 0;
+        uint64_t setFactionRelation = 0;
+        uint64_t pathfindRequest = 0;
+        uint64_t combatAttack = 0;
+        uint64_t characterUpdate = 0;
+        uint64_t aiUpdate = 0;
+    };
+
+    struct OnlineStructureOffsets
+    {
+        // Character
+        int32_t charPosition = 0x70;
+        int32_t charRotation = 0x7C;
+        int32_t charHealth = 0xC0;
+        int32_t charMaxHealth = 0xC4;
+        int32_t charBlood = 0xC8;
+        int32_t charHunger = 0xD0;
+        int32_t charInventory = 0xF0;
+        int32_t charEquipment = 0xF8;
+        int32_t charAI = 0x110;
+        int32_t charState = 0x118;
+        int32_t charFaction = 0x158;
+        int32_t charSquad = 0x168;
+        int32_t charAnimState = 0x140;
+        int32_t charBody = 0xB8;
+
+        // Squad
+        int32_t squadMembers = 0x20;
+        int32_t squadMemberCount = 0x28;
+        int32_t squadLeader = 0x30;
+        int32_t squadFactionId = 0x38;
+
+        // Faction
+        int32_t factionRelations = 0x20;
+        int32_t factionMembers = 0x30;
+        int32_t factionLeader = 0x40;
+
+        // Item
+        int32_t itemName = 0x10;
+        int32_t itemCategory = 0x18;
+        int32_t itemValue = 0x20;
+        int32_t itemWeight = 0x24;
+        int32_t itemStackCount = 0x28;
+    };
+
+    struct OnlinePatternDef
+    {
+        std::string name;
+        std::string pattern;
+        std::string mask;
+        int32_t offset = 0;
+        bool isRelative = false;
+        int32_t relativeBase = 0;
+    };
+
+    struct OnlineOffsetDatabase
+    {
+        int schemaVersion = 1;
+        std::string gameVersion;
+        bool isUniversal = false;
+        std::string lastUpdated;
+        std::string checksum;
+        std::string author;
+        std::string notes;
+
+        OnlineGameOffsets gameOffsets;
+        OnlineFunctionOffsets functionOffsets;
+        OnlineStructureOffsets structureOffsets;
+        std::unordered_map<std::string, OnlinePatternDef> patterns;
+
+        std::vector<std::string> supportedVersions;
+
+        bool isValid = false;
+    };
+
+    //=========================================================================
+    // ONLINE OFFSET FETCHER CLASS
+    //=========================================================================
+
+    class OnlineOffsetFetcher
+    {
+    public:
+        static OnlineOffsetFetcher& Get()
+        {
+            static OnlineOffsetFetcher instance;
+            return instance;
+        }
+
+        // Initialize with optional custom server URL
+        bool Initialize(const std::string& customServerUrl = "");
+
+        // Fetch offsets from online sources
+        bool FetchOffsets(const std::string& gameVersion = "");
+
+        // Get the loaded offset database
+        const OnlineOffsetDatabase& GetDatabase() const { return m_database; }
+
+        // Check if offsets are loaded
+        bool IsLoaded() const { return m_database.isValid; }
+
+        // Get specific offsets
+        const OnlineGameOffsets& GetGameOffsets() const { return m_database.gameOffsets; }
+        const OnlineFunctionOffsets& GetFunctionOffsets() const { return m_database.functionOffsets; }
+        const OnlineStructureOffsets& GetStructureOffsets() const { return m_database.structureOffsets; }
+
+        // Save/Load local cache
+        bool SaveCache(const std::string& filename = "kenshi_offsets_cache.dat");
+        bool LoadCache(const std::string& filename = "kenshi_offsets_cache.dat");
+
+        // Clear cache and force re-fetch
+        bool RefreshOffsets();
+
+        // Add custom server URL (inserted at beginning of list)
+        void AddServer(const std::string& url);
+
+        // Set callback for offset load events
+        using LoadCallback = std::function<void(bool success, const std::string& message)>;
+        void SetLoadCallback(LoadCallback callback) { m_loadCallback = callback; }
+
+        // Export current offsets as JSON
+        std::string ExportAsJson() const;
+
+    private:
+        OnlineOffsetFetcher();
+        ~OnlineOffsetFetcher() = default;
+        OnlineOffsetFetcher(const OnlineOffsetFetcher&) = delete;
+        OnlineOffsetFetcher& operator=(const OnlineOffsetFetcher&) = delete;
+
+        // HTTP fetch implementation
+        std::optional<std::string> FetchUrl(const std::string& url);
+
+        // JSON parsing
+        bool ParseJson(const std::string& json);
+        bool ParseGameOffsets(const std::string& json);
+        bool ParseFunctionOffsets(const std::string& json);
+        bool ParseStructureOffsets(const std::string& json);
+        bool ParsePatterns(const std::string& json);
+
+        // Validation
+        bool ValidateOffsets();
+        std::string CalculateChecksum();
+
+        // Helper functions
+        static std::string ExtractJsonValue(const std::string& json, const std::string& key);
+        static int64_t ExtractJsonNumber(const std::string& json, const std::string& key);
+        static bool ExtractJsonBool(const std::string& json, const std::string& key);
+        static std::string ExtractJsonObject(const std::string& json, const std::string& key);
+        static std::string ExtractJsonArray(const std::string& json, const std::string& key);
+
+        // Server URLs
+        std::vector<std::string> m_serverUrls;
+
+        // Loaded database
+        OnlineOffsetDatabase m_database;
+
+        // Callback
+        LoadCallback m_loadCallback;
+
+        // State
+        bool m_initialized = false;
+    };
+
+    //=========================================================================
+    // INTEGRATED OFFSET MANAGER (combines online + pattern scan + hardcoded)
+    //=========================================================================
+
+    class IntegratedOffsetManager
+    {
+    public:
+        static IntegratedOffsetManager& Get()
+        {
+            static IntegratedOffsetManager instance;
+            return instance;
+        }
+
+        // Initialize with priority: Online -> Pattern Scan -> Hardcoded
+        bool Initialize(HMODULE gameModule = nullptr);
+
+        // Get offset by category and name
+        uint64_t GetOffset(const std::string& category, const std::string& name) const;
+
+        // Get absolute address (moduleBase + offset)
+        uint64_t GetAbsolute(const std::string& category, const std::string& name) const;
+
+        // Get function address
+        uint64_t GetFunction(const std::string& name) const;
+
+        // Get structure offset
+        int32_t GetStructureOffset(const std::string& structure, const std::string& field) const;
+
+        // Check initialization status
+        bool IsOnlineLoaded() const { return m_onlineLoaded; }
+        bool IsPatternScanned() const { return m_patternScanned; }
+        bool IsInitialized() const { return m_initialized; }
+
+        // Get current source
+        enum class OffsetSource { Online, PatternScan, Hardcoded };
+        OffsetSource GetCurrentSource() const { return m_currentSource; }
+
+        // Force specific source
+        void SetSourcePriority(bool preferOnline, bool allowPatternScan);
+
+        // Reload offsets
+        bool Reload();
+
+    private:
+        IntegratedOffsetManager() = default;
+
+        // Apply online offsets to internal storage
+        void ApplyOnlineOffsets();
+
+        // Apply pattern-scanned offsets
+        void ApplyPatternOffsets();
+
+        // Apply hardcoded fallback
+        void ApplyHardcodedOffsets();
+
+        // Module info
+        uintptr_t m_moduleBase = 0;
+        uintptr_t m_moduleSize = 0;
+
+        // State
+        bool m_initialized = false;
+        bool m_onlineLoaded = false;
+        bool m_patternScanned = false;
+        OffsetSource m_currentSource = OffsetSource::Hardcoded;
+
+        // Preferences
+        bool m_preferOnline = true;
+        bool m_allowPatternScan = true;
+
+        // Storage
+        std::unordered_map<std::string, uint64_t> m_offsets;
+        std::unordered_map<std::string, uint64_t> m_functions;
+        std::unordered_map<std::string, int32_t> m_structureOffsets;
+    };
+
+} // namespace Kenshi

--- a/offsets/README.md
+++ b/offsets/README.md
@@ -1,0 +1,123 @@
+# Kenshi Online Offset Database
+
+This folder contains the online offset database for the Kenshi-Online multiplayer mod.
+
+## File Structure
+
+- `kenshi_offsets.json` - Main offset database (auto-downloaded by clients)
+- `README.md` - This documentation file
+
+## JSON Schema
+
+The offset database follows this structure:
+
+```json
+{
+  "version": 1,                          // Schema version
+  "gameVersion": "1.0.64",               // Target game version
+  "isUniversal": false,                  // If true, works across versions
+  "lastUpdated": "2025-12-08T00:00:00Z", // Last update timestamp
+  "author": "The404Studios",
+  "notes": "Description",
+  "checksum": "",                        // SHA256 of offsets object (optional)
+
+  "offsets": {
+    // Core game pointer offsets (RVA from module base)
+    "baseAddress": 5368709120,           // 0x140000000
+    "worldInstance": 38633280,           // 0x24D8F40
+    // ... more offsets
+  },
+
+  "functionOffsets": {
+    // Function address offsets (RVA)
+    "spawnCharacter": 9125000,           // 0x8B3C80
+    // ... more functions
+  },
+
+  "structureOffsets": {
+    // In-structure field offsets
+    "character": {
+      "position": 112,                   // 0x70
+      // ... more fields
+    }
+  },
+
+  "patterns": {
+    // Pattern signatures for dynamic scanning
+    "gameWorld": {
+      "name": "GameWorld",
+      "pattern": "48 8B 05 ?? ?? ?? ??",
+      "mask": "xxx????",
+      "offset": 3,
+      "isRelative": true,
+      "relativeBase": 7
+    }
+  },
+
+  "supportedVersions": ["1.0.64", "1.0.63"]
+}
+```
+
+## Offset Types
+
+### 1. Game Offsets (`offsets`)
+Relative Virtual Addresses (RVA) from the game's module base address.
+- Use decimal values in JSON
+- Calculate absolute: `moduleBase + offset`
+
+### 2. Function Offsets (`functionOffsets`)
+RVA addresses for game functions that can be hooked or called.
+
+### 3. Structure Offsets (`structureOffsets`)
+Byte offsets within game structures (Character, Squad, etc.)
+
+### 4. Pattern Signatures (`patterns`)
+Byte patterns for dynamic offset discovery:
+- `pattern`: Hex bytes (space separated), `??` for wildcards
+- `mask`: `x` = exact match, `?` = wildcard
+- `offset`: Bytes from pattern start to read target
+- `isRelative`: If true, value is RIP-relative offset
+- `relativeBase`: Instruction size for relative calculation
+
+## Updating Offsets
+
+When Kenshi updates:
+
+1. **Detect new version**: Check game executable version
+2. **Pattern scan first**: Most patterns remain valid across versions
+3. **Manual verification**: Use Cheat Engine or x64dbg to verify
+4. **Update JSON**: Modify values and bump `lastUpdated`
+5. **Test thoroughly**: Verify all mod functionality
+
+## Hosting
+
+The offset file is served from multiple locations for redundancy:
+1. GitHub repository (raw file)
+2. Dedicated API server
+3. Backup Pastebin/Gist
+
+## Client Behavior
+
+1. On startup, client fetches latest offsets
+2. Validates checksum (if provided)
+3. Caches locally for offline use
+4. Falls back to hardcoded values if all sources fail
+
+## Converting Values
+
+```
+Decimal to Hex: 38633280 → 0x24D8F40
+Hex to Decimal: 0x24D8F40 → 38633280
+
+Python: hex(38633280), int('24D8F40', 16)
+```
+
+## Version-Specific Notes
+
+### Kenshi 1.0.64
+- Current stable version
+- All offsets verified
+
+### Kenshi 1.0.65+ (Future)
+- May require pattern re-scanning
+- Structure offsets likely unchanged

--- a/offsets/kenshi_offsets.json
+++ b/offsets/kenshi_offsets.json
@@ -1,0 +1,180 @@
+{
+  "version": 1,
+  "gameVersion": "1.0.64",
+  "isUniversal": false,
+  "lastUpdated": "2025-12-08T00:00:00Z",
+  "author": "The404Studios",
+  "notes": "Kenshi v1.0.64 (64-bit Steam/GOG) offset database for Kenshi-Online multiplayer mod",
+  "checksum": "",
+  "offsets": {
+    "baseAddress": 5368709120,
+    "worldInstance": 38633280,
+    "gameState": 38633288,
+    "gameTime": 38633296,
+    "gameDay": 38633304,
+    "playerSquadList": 38558240,
+    "playerSquadCount": 38558248,
+    "allCharactersList": 38558464,
+    "allCharactersCount": 38558472,
+    "selectedCharacter": 38558256,
+    "factionList": 38600960,
+    "factionCount": 38600968,
+    "playerFaction": 38600976,
+    "relationMatrix": 38601216,
+    "buildingList": 38662144,
+    "buildingCount": 38662152,
+    "worldItemsList": 38662400,
+    "worldItemsCount": 38662408,
+    "weatherSystem": 38686720,
+    "physicsWorld": 38731776,
+    "camera": 38698016,
+    "cameraTarget": 38698040,
+    "renderer": 38752256,
+    "inputHandler": 38722944,
+    "commandQueue": 38722960,
+    "selectedUnits": 38722976,
+    "uiState": 38727680
+  },
+  "functionOffsets": {
+    "spawnCharacter": 9125000,
+    "despawnCharacter": 9126176,
+    "addToSquad": 9127168,
+    "removeFromSquad": 9127424,
+    "addItemToInventory": 10231040,
+    "removeItemFromInventory": 10231296,
+    "setCharacterState": 9179136,
+    "issueCommand": 9261056,
+    "createFaction": 8003584,
+    "setFactionRelation": 8004864,
+    "pathfindRequest": 8065024,
+    "combatAttack": 9306112,
+    "characterUpdate": 0,
+    "aiUpdate": 0
+  },
+  "structureOffsets": {
+    "character": {
+      "position": 112,
+      "rotation": 124,
+      "health": 192,
+      "maxHealth": 196,
+      "blood": 200,
+      "hunger": 208,
+      "inventory": 240,
+      "equipment": 248,
+      "ai": 272,
+      "state": 280,
+      "faction": 344,
+      "squad": 360,
+      "animState": 320,
+      "body": 184
+    },
+    "squad": {
+      "members": 32,
+      "memberCount": 40,
+      "leader": 48,
+      "factionId": 56
+    },
+    "faction": {
+      "relations": 32,
+      "members": 48,
+      "leader": 64
+    },
+    "item": {
+      "name": 16,
+      "category": 24,
+      "value": 32,
+      "weight": 36,
+      "stackCount": 40
+    }
+  },
+  "patterns": {
+    "gameWorld": {
+      "name": "GameWorld",
+      "pattern": "48 8B 05 ?? ?? ?? ?? 48 85 C0 74 ?? 48 8B 40 08",
+      "mask": "xxx????xxxx?xxxx",
+      "offset": 3,
+      "isRelative": true,
+      "relativeBase": 7
+    },
+    "playerSquadList": {
+      "name": "PlayerSquadList",
+      "pattern": "48 8D 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 8B D8",
+      "mask": "xxx????x????xxx",
+      "offset": 3,
+      "isRelative": true,
+      "relativeBase": 7
+    },
+    "allCharactersList": {
+      "name": "AllCharactersList",
+      "pattern": "48 8B 05 ?? ?? ?? ?? 48 8B 04 C8 48 85 C0",
+      "mask": "xxx????xxxxxxx",
+      "offset": 3,
+      "isRelative": true,
+      "relativeBase": 7
+    },
+    "factionManager": {
+      "name": "FactionManager",
+      "pattern": "48 8B 0D ?? ?? ?? ?? E8 ?? ?? ?? ?? 48 8B C8 48 8B 10",
+      "mask": "xxx????x????xxxxxx",
+      "offset": 3,
+      "isRelative": true,
+      "relativeBase": 7
+    },
+    "weatherSystem": {
+      "name": "WeatherSystem",
+      "pattern": "48 8B 05 ?? ?? ?? ?? F3 0F 10 40 ?? F3 0F 58 05",
+      "mask": "xxx????xxxx?xxxx",
+      "offset": 3,
+      "isRelative": true,
+      "relativeBase": 7
+    },
+    "inputHandler": {
+      "name": "InputHandler",
+      "pattern": "48 8B 0D ?? ?? ?? ?? 48 8B 01 FF 50 ?? 84 C0",
+      "mask": "xxx????xxxxx?xx",
+      "offset": 3,
+      "isRelative": true,
+      "relativeBase": 7
+    },
+    "cameraController": {
+      "name": "CameraController",
+      "pattern": "48 8B 05 ?? ?? ?? ?? 48 8B 48 08 F3 0F 10",
+      "mask": "xxx????xxxxxxx",
+      "offset": 3,
+      "isRelative": true,
+      "relativeBase": 7
+    },
+    "spawnCharacter": {
+      "name": "SpawnCharacter",
+      "pattern": "48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 40 48 8B F2 48 8B F9",
+      "mask": "xxxx?xxxx?xxxxxxxxxxx",
+      "offset": 0,
+      "isRelative": false,
+      "relativeBase": 0
+    },
+    "characterUpdate": {
+      "name": "CharacterUpdate",
+      "pattern": "48 89 5C 24 ?? 48 89 6C 24 ?? 48 89 74 24 ?? 57 41 56 41 57 48 83 EC 20 48 8B E9",
+      "mask": "xxxx?xxxx?xxxx?xxxxxxxxxxxx",
+      "offset": 0,
+      "isRelative": false,
+      "relativeBase": 0
+    },
+    "combatSystem": {
+      "name": "CombatSystem",
+      "pattern": "48 89 5C 24 ?? 55 56 57 41 54 41 55 41 56 41 57 48 8D 6C 24 ?? 48 81 EC ?? ?? ?? ?? 4C 8B F2",
+      "mask": "xxxx?xxxxxxxxxxxxxxx?xxx????xxx",
+      "offset": 0,
+      "isRelative": false,
+      "relativeBase": 0
+    }
+  },
+  "supportedVersions": [
+    "1.0.64",
+    "1.0.63",
+    "1.0.62",
+    "1.0.61",
+    "1.0.60",
+    "1.0.59"
+  ]
+}


### PR DESCRIPTION
- Add OnlineOffsetProvider.cs: C# class for fetching offsets from remote servers
  - Supports multiple fallback servers (GitHub raw, API, backup)
  - Local caching with 7-day expiration
  - Checksum validation for security
  - RuntimeOffsets static class for easy access

- Add OnlineOffsetFetcher.h/cpp: C++ native implementation
  - WinHTTP-based URL fetching
  - JSON parsing for offset database
  - IntegratedOffsetManager combining online/pattern/hardcoded sources
  - Binary cache format for fast loading

- Update KenshiStructures.cs:
  - Add InitializeOnlineOffsets() method
  - Add GetOffset() and GetAbsoluteAddress() dynamic accessors
  - Integrate with OnlineOffsetProvider

- Add offsets/kenshi_offsets.json:
  - Complete offset database for Kenshi v1.0.64
  - Game offsets, function offsets, structure offsets
  - Pattern signatures for dynamic scanning
  - Documentation in offsets/README.md

Priority fallback chain: Online -> Pattern Scan -> Hardcoded