### PR TITLE
Restore .gitmodules to fix dependency fetch on fresh clone

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,15 @@
+[submodule "lib/enet"]
+	path = lib/enet
+	url = https://github.com/lsalzman/enet.git
+[submodule "lib/imgui"]
+	path = lib/imgui
+	url = https://github.com/ocornut/imgui.git
+[submodule "lib/json"]
+	path = lib/json
+	url = https://github.com/nlohmann/json.git
+[submodule "lib/minhook"]
+	path = lib/minhook
+	url = https://github.com/TsudaKageyu/minhook.git
+[submodule "lib/spdlog"]
+	path = lib/spdlog
+	url = https://github.com/gabime/spdlog.git


### PR DESCRIPTION
The five lib/ dependencies (enet, imgui, json, minhook, spdlog) are recorded as submodule gitlinks but .gitmodules was missing, so `git submodule update --init` (run by build.bat) fetched nothing and the build failed with empty lib/ folders.

Reconstruct .gitmodules mapping each path to its upstream URL. The pinned commits resolve cleanly against these repos:
  enet    -> lsalzman/enet
  imgui   -> ocornut/imgui
  json    -> nlohmann/json
  minhook -> TsudaKageyu/minhook
  spdlog  -> gabime/spdlog