### PR TITLE
cmake: include missing sources for issue 87

### DIFF
--- a/KenshiMP.Core/CMakeLists.txt
+++ b/KenshiMP.Core/CMakeLists.txt
@@ -46,6 +46,9 @@ add_library(KenshiMP.Core SHARED
     sync/interpolation.cpp
     sync/ownership.cpp
     sync/zone_interest.cpp
+    sync/authority_validator.cpp
+    sync/pending_snapshot_queue.cpp
+    sync/deferred_spawn_queue.cpp
     sync/entity_resolver.cpp
     sync/zone_engine.cpp
     sync/player_engine.cpp

--- a/KenshiMP.Server/CMakeLists.txt
+++ b/KenshiMP.Server/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(KenshiMP.Server
     main.cpp
     server.cpp
+    authority_validator.cpp
     upnp.cpp
     game_state.cpp
     player_manager.cpp


### PR DESCRIPTION
## Summary

This fixes the linker failure reported in #87.

The implementation files are present in the repository, but several of them were not included in the corresponding CMake target source lists. As a result, the Release build failed with unresolved externals / `LNK2019` and `LNK1120`.

This PR adds the existing implementation files to the Core and Server CMake targets.

## Changes

Added to `KenshiMP.Core/CMakeLists.txt`:

- `sync/authority_validator.cpp`
- `sync/pending_snapshot_queue.cpp`
- `sync/deferred_spawn_queue.cpp`

Added to `KenshiMP.Server/CMakeLists.txt`:

- `authority_validator.cpp`

## Validation

Validated locally on Windows with a Release build:

- `KenshiMP.Server.exe` builds successfully
- `KenshiMP.Core.dll` builds successfully
- Release build completes successfully
- `LNK2019` / `LNK1120` errors are resolved
- Unit tests: 95 passed, 0 failed
- `git diff --check`: no errors

## Scope

This is a build-system-only fix.

No runtime logic, networking, hooks, offsets, spawn logic, installer logic, or gameplay behavior was changed.

Fixes #87.