### PR TITLE
build: restore dependency recovery for clean checkouts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,15 @@
+[submodule "lib/enet"]
+	path = lib/enet
+	url = https://github.com/lsalzman/enet.git
+[submodule "lib/imgui"]
+	path = lib/imgui
+	url = https://github.com/ocornut/imgui.git
+[submodule "lib/json"]
+	path = lib/json
+	url = https://github.com/nlohmann/json.git
+[submodule "lib/minhook"]
+	path = lib/minhook
+	url = https://github.com/TsudaKageyu/minhook.git
+[submodule "lib/spdlog"]
+	path = lib/spdlog
+	url = https://github.com/gabime/spdlog.git

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ```bash
 # 1. Clone
-git clone https://github.com/The404Studios/Kenshi-Online.git
+git clone --recursive https://github.com/The404Studios/Kenshi-Online.git
 cd Kenshi-Online
 
 # 2. Build

--- a/build.bat
+++ b/build.bat
@@ -30,9 +30,21 @@ if exist "%ProgramFiles%\Microsoft Visual Studio\2022" (
     goto :fail
 )
 
-:: ── Check submodules ──
-if not exist "lib\enet\CMakeLists.txt" (
-    echo [WARN] Submodules not initialized. Running git submodule update...
+:: ── Check required submodules ──
+set "NEED_SUBMODULES="
+if not exist "lib\enet\CMakeLists.txt" set "NEED_SUBMODULES=1"
+if not exist "lib\minhook\CMakeLists.txt" set "NEED_SUBMODULES=1"
+if not exist "lib\spdlog\CMakeLists.txt" set "NEED_SUBMODULES=1"
+if not exist "lib\json\CMakeLists.txt" set "NEED_SUBMODULES=1"
+
+if defined NEED_SUBMODULES (
+    echo [WARN] Required submodules are not initialized. Running git submodule update...
+    where git >nul 2>&1
+    if errorlevel 1 (
+        echo [ERROR] Git not found in PATH.
+        echo         Install Git or clone the repository with --recursive.
+        goto :fail
+    )
     git submodule update --init --recursive
     if errorlevel 1 (
         echo [ERROR] Failed to initialize submodules.
@@ -40,6 +52,25 @@ if not exist "lib\enet\CMakeLists.txt" (
         goto :fail
     )
 )
+
+set "MISSING_DEPENDENCIES="
+if not exist "lib\enet\CMakeLists.txt" (
+    echo [ERROR] Missing dependency: lib\enet
+    set "MISSING_DEPENDENCIES=1"
+)
+if not exist "lib\minhook\CMakeLists.txt" (
+    echo [ERROR] Missing dependency: lib\minhook
+    set "MISSING_DEPENDENCIES=1"
+)
+if not exist "lib\spdlog\CMakeLists.txt" (
+    echo [ERROR] Missing dependency: lib\spdlog
+    set "MISSING_DEPENDENCIES=1"
+)
+if not exist "lib\json\CMakeLists.txt" (
+    echo [ERROR] Missing dependency: lib\json
+    set "MISSING_DEPENDENCIES=1"
+)
+if defined MISSING_DEPENDENCIES goto :fail
 
 :: ── Configure ──
 echo.

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -48,13 +48,17 @@ This document covers CMake configuration, dependencies, build targets, project d
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/The404Studios/Kenshi-Online.git
+git clone --recursive https://github.com/The404Studios/Kenshi-Online.git
 cd Kenshi-Online
 ```
 
-### 2. Initialize Submodules (if present)
+### 2. Initialize Submodules
 
-All dependencies are currently included in `lib/` directory. No separate submodule initialization needed.
+Third-party dependencies are pinned Git submodules in `lib/`. If the repository was cloned without `--recursive`, initialize them before configuring CMake:
+
+```bash
+git submodule update --init --recursive
+```
 
 ### 3. Generate Build Files
 
@@ -98,7 +102,7 @@ All third-party libraries are located in `lib/` and built automatically via CMak
 
 ### 1. ENet (Networking)
 
-- **Version:** Latest from https://github.com/lsalzman/enet
+- **Version:** Pinned commit `8be2368a8001f28db44e81d5939de5e613025023` from https://github.com/lsalzman/enet
 - **Purpose:** Reliable UDP networking library for client-server communication
 - **Build Type:** Static library (`enet.lib`)
 - **CMake Target:** `enet`
@@ -115,7 +119,7 @@ target_include_directories(enet PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/lib/enet/incl
 
 ### 2. MinHook (Function Hooking)
 
-- **Version:** Latest from https://github.com/TsudaKageyu/minhook
+- **Version:** Pinned commit `1e9ad1eb42db11bfcb65461f687c656612d1b555` from https://github.com/TsudaKageyu/minhook
 - **Purpose:** x64 function hooking via trampoline technique
 - **Build Type:** Static library (`minhook.lib`)
 - **CMake Target:** `minhook`
@@ -131,7 +135,7 @@ add_subdirectory(lib/minhook)
 
 ### 3. spdlog (Logging)
 
-- **Version:** Latest from https://github.com/gabime/spdlog
+- **Version:** Pinned commit `48bcf39a661a13be22666ac64db8a7f886f2637e` from https://github.com/gabime/spdlog
 - **Purpose:** Fast C++ logging library
 - **Build Type:** Header-only mode
 - **CMake Target:** `spdlog::spdlog`
@@ -148,7 +152,7 @@ add_subdirectory(lib/spdlog EXCLUDE_FROM_ALL)
 
 ### 4. nlohmann/json (JSON Parsing)
 
-- **Version:** Latest from https://github.com/nlohmann/json
+- **Version:** Pinned commit `9cca280a4d0ccf0c08f47a99aa71d1b0e52f8d03` from https://github.com/nlohmann/json
 - **Purpose:** JSON serialization/deserialization
 - **Build Type:** Header-only
 - **CMake Target:** `nlohmann_json::nlohmann_json`
@@ -166,6 +170,7 @@ add_subdirectory(lib/json EXCLUDE_FROM_ALL)
 ### 5. imgui (Optional, currently unused)
 
 - **Location:** `lib/imgui/`
+- **Version:** Pinned commit `dbb5eeaadffb6a3ba6a60de1290312e5802dba5a` from https://github.com/ocornut/imgui
 - **Status:** Included but not currently linked to any project
 - **Note:** Native MyGUI overlay is used instead for in-game UI
 
@@ -786,13 +791,11 @@ target_link_libraries(KenshiMP.Scanner PUBLIC
 MinHook: Could not find hde64.c
 ```
 
-**Cause:** Incomplete MinHook submodule.
+**Cause:** MinHook submodule is not initialized or is incomplete.
 
 **Fix:**
 ```bash
-cd lib/minhook
-git pull origin master
-cd ../..
+git submodule update --init --checkout lib/minhook
 cmake --build build --target minhook --config Release
 ```
 
@@ -812,9 +815,8 @@ error: nlohmann/json.hpp: No such file or directory
 # Check if lib/json exists
 ls lib/json/
 
-# If empty, reclone
-rm -rf lib/json
-git clone https://github.com/nlohmann/json.git lib/json
+# If empty, restore the pinned submodule revision
+git submodule update --init --checkout lib/json
 
 # Rebuild
 cmake --build build --config Release


### PR DESCRIPTION
## Summary

This PR restores reproducible dependency recovery for clean checkouts.

The repository already contains pinned gitlinks for third-party dependencies, but the submodule metadata was missing. As a result, a normal clone could leave required `lib/*` dependency directories empty, causing configure/build failures unless the dependencies were restored manually.

This PR adds the missing `.gitmodules` metadata and updates the Windows build path and documentation so dependency recovery is explicit and reproducible.

## Changes

- Add `.gitmodules` entries for the existing pinned dependency gitlinks.
- Update `build.bat` to restore and validate required third-party dependencies before configure.
- Update `README.md` and `docs/BUILD.md` with reproducible build instructions.
- Avoid floating `latest` dependency instructions.

## Validation

Validated locally on Windows:

- `git submodule update --init --recursive` restored all dependencies successfully
- All five submodules are checked out at their gitlink SHA
- CMake configure completed successfully
- ENet built successfully
- MinHook built successfully
- `KenshiMP.UnitTest` built successfully
- Unit tests: 95 passed, 0 failed
- `git diff --check`: no errors

## Scope

This is a build/dependency-recovery and documentation fix only.

No runtime logic, networking, hooks, offsets, spawn logic, installer logic, crash fixes, or gameplay behavior changed.
