### PR TITLE
Integrate Windows build, installer, and multiplayer hardening

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,113 @@
+name: Windows Release build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and test
+    runs-on: windows-2022
+    timeout-minutes: 45
+
+    steps:
+      - name: Check out pinned dependencies
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Verify clean checkout and submodule revisions
+        shell: pwsh
+        run: |
+          if (Test-Path build) {
+            throw "The checkout unexpectedly contains a pre-existing build directory."
+          }
+
+          $submodules = @(
+            "lib/enet",
+            "lib/imgui",
+            "lib/json",
+            "lib/minhook",
+            "lib/spdlog"
+          )
+
+          foreach ($path in $submodules) {
+            $entry = git ls-tree HEAD -- $path
+            if ($LASTEXITCODE -ne 0 -or -not $entry) {
+              throw "Missing gitlink for $path."
+            }
+
+            $fields = $entry -split '\s+'
+            if ($fields[1] -ne "commit") {
+              throw "$path is not recorded as a gitlink."
+            }
+
+            $expected = $fields[2]
+            $actual = git -C $path rev-parse HEAD
+            if ($LASTEXITCODE -ne 0) {
+              throw "Unable to read the checked out revision for $path."
+            }
+
+            if ($actual.Trim() -ne $expected) {
+              throw "$path is at $actual instead of pinned revision $expected."
+            }
+
+            Write-Host "$path -> $expected"
+          }
+
+      - name: Configure Release build
+        run: cmake --preset x64-release
+
+      - name: Build Release targets
+        run: cmake --build --preset release --parallel
+
+      - name: Verify required build outputs
+        shell: pwsh
+        run: |
+          $required = @(
+            "build/lib/Release/enet.lib",
+            "build/lib/Release/minhook.x64.lib",
+            "build/bin/Release/KenshiMP.Core.dll",
+            "build/bin/Release/KenshiMP.Server.exe",
+            "build/bin/Release/KenshiMP.Injector.exe",
+            "build/bin/Release/KenshiMP.UnitTest.exe"
+          )
+
+          $missing = $required | Where-Object { -not (Test-Path $_ -PathType Leaf) }
+          if ($missing) {
+            $missing | ForEach-Object { Write-Error "Missing build output: $_" }
+            throw "The Release build did not produce every required output."
+          }
+
+          Get-Item $required | Select-Object FullName, Length
+
+      - name: Run unit tests
+        run: .\build\bin\Release\KenshiMP.UnitTest.exe
+
+      - name: Upload diagnostic build outputs
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-release-${{ github.sha }}
+          if-no-files-found: error
+          retention-days: 7
+          path: |
+            build/bin/Release/KenshiMP.Core.dll
+            build/bin/Release/KenshiMP.Core.map
+            build/bin/Release/KenshiMP.Core.pdb
+            build/bin/Release/KenshiMP.Server.exe
+            build/bin/Release/KenshiMP.Server.pdb
+            build/bin/Release/KenshiMP.Injector.exe
+            build/bin/Release/KenshiMP.Injector.pdb
+            build/bin/Release/KenshiMP.UnitTest.exe
+            build/bin/Release/KenshiMP.UnitTest.pdb

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,15 @@
+[submodule "lib/enet"]
+	path = lib/enet
+	url = https://github.com/lsalzman/enet.git
+[submodule "lib/imgui"]
+	path = lib/imgui
+	url = https://github.com/ocornut/imgui.git
+[submodule "lib/json"]
+	path = lib/json
+	url = https://github.com/nlohmann/json.git
+[submodule "lib/minhook"]
+	path = lib/minhook
+	url = https://github.com/TsudaKageyu/minhook.git
+[submodule "lib/spdlog"]
+	path = lib/spdlog
+	url = https://github.com/gabime/spdlog.git

--- a/KenshiMP.Core/CMakeLists.txt
+++ b/KenshiMP.Core/CMakeLists.txt
@@ -46,6 +46,9 @@ add_library(KenshiMP.Core SHARED
     sync/interpolation.cpp
     sync/ownership.cpp
     sync/zone_interest.cpp
+    sync/authority_validator.cpp
+    sync/pending_snapshot_queue.cpp
+    sync/deferred_spawn_queue.cpp
     sync/entity_resolver.cpp
     sync/zone_engine.cpp
     sync/player_engine.cpp

--- a/KenshiMP.Core/core.cpp
+++ b/KenshiMP.Core/core.cpp
@@ -68,8 +68,41 @@ static void WriteBreadcrumb(const char* step, int tickNum = 0, int extra = 0) {
     if (tickNum > 50 && tickNum % 10 != 0) return; // Skip most ticks after warmup
     s_writeCount++;
 
+    // Resolve the breadcrumb path relative to the running executable so users
+    // with GOG, non-default Steam libraries, or portable installs still get
+    // crash diagnostics. Previously hardcoded to the Steam default path, which
+    // silently failed for most users.
+    static char s_breadcrumbPath[MAX_PATH] = {};
+    if (s_breadcrumbPath[0] == '\0') {
+        char exePath[MAX_PATH] = {};
+        DWORD len = GetModuleFileNameA(nullptr, exePath, MAX_PATH);
+        if (len > 0 && len < MAX_PATH) {
+            char* lastSep = nullptr;
+            for (char* p = exePath; *p; ++p) {
+                if (*p == '\\' || *p == '/') lastSep = p;
+            }
+            if (lastSep) {
+                *lastSep = '\0';
+                sprintf_s(s_breadcrumbPath, sizeof(s_breadcrumbPath),
+                          "%s\\KenshiOnline_BREADCRUMB.txt", exePath);
+            }
+        }
+        if (s_breadcrumbPath[0] == '\0') {
+            // Fall back to the temp directory so the write doesn't fail outright.
+            char tempDir[MAX_PATH] = {};
+            DWORD tlen = GetTempPathA(MAX_PATH, tempDir);
+            if (tlen > 0 && tlen < MAX_PATH) {
+                sprintf_s(s_breadcrumbPath, sizeof(s_breadcrumbPath),
+                          "%sKenshiOnline_BREADCRUMB.txt", tempDir);
+            } else {
+                strcpy_s(s_breadcrumbPath, sizeof(s_breadcrumbPath),
+                         "KenshiOnline_BREADCRUMB.txt");
+            }
+        }
+    }
+
     FILE* f = nullptr;
-    fopen_s(&f, "C:\\Program Files (x86)\\Steam\\steamapps\\common\\Kenshi\\KenshiOnline_BREADCRUMB.txt", "w");
+    fopen_s(&f, s_breadcrumbPath, "w");
     if (f) {
         fprintf(f, "tick=%d step=%s extra=%d charCreate=#%d writes=%d\n",
                 tickNum, step, extra, g_lastCharacterCreateNum, s_writeCount);

--- a/KenshiMP.Core/game/spawn_manager.cpp
+++ b/KenshiMP.Core/game/spawn_manager.cpp
@@ -776,6 +776,41 @@ void SpawnManager::FindModTemplates() {
 void* SpawnManager::SpawnWithModTemplate(int playerSlot, const Vec3& position) {
     if (playerSlot < 0 || playerSlot >= MAX_MOD_TEMPLATES) return nullptr;
     void* modGD = m_modPlayerTemplates[playerSlot];
+
+    // Multi-player fallback: kenshi-online.mod currently ships with only
+    // "Player 1" and "Player 2" GameData entries (see strings inside the .mod).
+    // When >2 players are connected and the per-slot template hasn't been
+    // populated, fall back to the nearest available slot below us and finally
+    // to any captured character template. Without this, players 3-16 would
+    // simply fail to spawn for everyone else (#82).
+    if (!modGD) {
+        int templateCount = m_modTemplateCount.load();
+        if (templateCount > 0) {
+            int slot = playerSlot % templateCount;
+            if (slot >= 0 && slot < MAX_MOD_TEMPLATES) {
+                modGD = m_modPlayerTemplates[slot];
+            }
+            if (!modGD) {
+                for (int s = 0; s < MAX_MOD_TEMPLATES && !modGD; ++s) {
+                    modGD = m_modPlayerTemplates[s];
+                }
+            }
+        }
+        if (!modGD) {
+            std::lock_guard lock(m_templateMutex);
+            if (m_lastCharacterTemplate) {
+                modGD = m_lastCharacterTemplate;
+            } else if (m_characterSourcedTemplate) {
+                modGD = m_characterSourcedTemplate;
+            }
+        }
+        if (modGD) {
+            spdlog::info("SpawnManager: SpawnWithModTemplate slot={} fell back to template 0x{:X} "
+                         "(slot template missing — mod only ships Players 1-2)",
+                         playerSlot, reinterpret_cast<uintptr_t>(modGD));
+        }
+    }
+
     if (!modGD) return nullptr;
     // Only m_factory is needed — CallFactoryCreate uses its own function pointer
     // (RVA 0x583400), not m_origProcess (the process trampoline).

--- a/KenshiMP.Core/net/client.cpp
+++ b/KenshiMP.Core/net/client.cpp
@@ -166,12 +166,20 @@ void NetworkClient::Update() {
 }
 
 void NetworkClient::Send(const uint8_t* data, size_t len, int channel, uint32_t flags) {
-    if (!m_connected || !m_serverPeer) return;
-
+    // Take the lock first, then re-check connection state. The peer can be
+    // reset to nullptr by Update() running on a different thread between the
+    // check and the enet_peer_send call below — without the lock the send
+    // would touch freed memory and crash (#69).
     std::lock_guard lock(m_enetMutex);
+    if (!m_connected || !m_serverPeer || !m_host) return;
+    if (!data || len == 0) return;
+
     ENetPacket* packet = enet_packet_create(data, len, flags);
-    if (packet) {
-        enet_peer_send(m_serverPeer, channel, packet);
+    if (!packet) return;
+
+    if (enet_peer_send(m_serverPeer, channel, packet) < 0) {
+        // enet_peer_send takes ownership on success; destroy on failure.
+        enet_packet_destroy(packet);
     }
 }
 

--- a/KenshiMP.Core/net/client.cpp
+++ b/KenshiMP.Core/net/client.cpp
@@ -1,7 +1,13 @@
 #include "client.h"
 #include <spdlog/spdlog.h>
+#include <chrono>
 
 namespace kmp {
+
+static float NowSeconds() {
+    using namespace std::chrono;
+    return duration_cast<duration<float>>(steady_clock::now().time_since_epoch()).count();
+}
 
 bool NetworkClient::Initialize() {
     if (m_initialized) return true;
@@ -40,8 +46,13 @@ bool NetworkClient::Connect(const std::string& address, uint16_t port) {
     // Blocking connect — kept for compatibility but prefer ConnectAsync()
     if (!m_initialized || m_connected) return false;
 
+    std::lock_guard lock(m_enetMutex);
+
     ENetAddress addr;
-    enet_address_set_host(&addr, address.c_str());
+    if (enet_address_set_host(&addr, address.c_str()) != 0) {
+        spdlog::error("NetworkClient: Failed to resolve host '{}'", address);
+        return false;
+    }
     addr.port = port;
 
     m_serverPeer = enet_host_connect(m_host, &addr, KMP_CHANNEL_COUNT, 0);
@@ -63,8 +74,11 @@ bool NetworkClient::Connect(const std::string& address, uint16_t port) {
         return true;
     }
 
-    enet_peer_reset(m_serverPeer);
-    m_serverPeer = nullptr;
+    // Failed to connect — drain any pending events so we don't leak state
+    if (m_serverPeer) {
+        enet_peer_reset(m_serverPeer);
+        m_serverPeer = nullptr;
+    }
     spdlog::error("NetworkClient: Connection to {}:{} timed out", address, port);
     return false;
 }
@@ -72,8 +86,13 @@ bool NetworkClient::Connect(const std::string& address, uint16_t port) {
 bool NetworkClient::ConnectAsync(const std::string& address, uint16_t port) {
     if (!m_initialized || m_connected || m_connecting) return false;
 
+    std::lock_guard lock(m_enetMutex);
+
     ENetAddress addr;
-    enet_address_set_host(&addr, address.c_str());
+    if (enet_address_set_host(&addr, address.c_str()) != 0) {
+        spdlog::error("NetworkClient: Failed to resolve host '{}' for async connect", address);
+        return false;
+    }
     addr.port = port;
 
     m_serverPeer = enet_host_connect(m_host, &addr, KMP_CHANNEL_COUNT, 0);
@@ -88,31 +107,36 @@ bool NetworkClient::ConnectAsync(const std::string& address, uint16_t port) {
     m_connecting = true;
     m_serverAddr = address;
     m_serverPort = port;
+    m_connectStartTime = NowSeconds();
     spdlog::info("NetworkClient: Async connecting to {}:{}...", address, port);
     return true;
 }
 
 void NetworkClient::Disconnect() {
+    std::lock_guard lock(m_enetMutex);
     if (m_serverPeer) {
         if (m_connected) {
             enet_peer_disconnect(m_serverPeer, 0);
 
-            // Wait briefly for disconnect acknowledgment
+            // Wait briefly for disconnect acknowledgment, bounded so the UI
+            // thread can't hang forever if the server is unresponsive.
             ENetEvent event;
             bool disconnected = false;
-            while (enet_host_service(m_host, &event, 1000) > 0) {
+            const int attempts = 3;
+            for (int i = 0; i < attempts && !disconnected; ++i) {
+                int rc = enet_host_service(m_host, &event, 500);
+                if (rc <= 0) break;
                 if (event.type == ENET_EVENT_TYPE_RECEIVE) {
                     enet_packet_destroy(event.packet);
                 } else if (event.type == ENET_EVENT_TYPE_DISCONNECT) {
                     disconnected = true;
-                    break;
                 }
             }
 
-            if (!disconnected) {
+            if (!disconnected && m_serverPeer) {
                 enet_peer_reset(m_serverPeer);
             }
-        } else {
+        } else if (m_serverPeer) {
             enet_peer_reset(m_serverPeer);
         }
     }
@@ -130,6 +154,21 @@ void NetworkClient::Update() {
     // Lock covers enet_host_service which shares internal state with enet_peer_send.
     // The 0 timeout makes this non-blocking, so lock contention is minimal.
     std::lock_guard lock(m_enetMutex);
+
+    // Detect async-connect timeout. ENet sets the peer state to DISCONNECTED
+    // internally on timeout, but it does not generate a DISCONNECT event for a
+    // peer that never finished CONNECT — so we have to time it out ourselves.
+    if (m_connecting && m_serverPeer) {
+        float elapsed = NowSeconds() - m_connectStartTime;
+        if (elapsed > (KMP_CONNECT_TIMEOUT_MS / 1000.0f) + 1.0f) {
+            spdlog::warn("NetworkClient: Async connect to {}:{} timed out after {:.1f}s",
+                         m_serverAddr, m_serverPort, elapsed);
+            enet_peer_reset(m_serverPeer);
+            m_serverPeer = nullptr;
+            m_connecting = false;
+        }
+    }
+
     while (enet_host_service(m_host, &event, 0) > 0) {
         switch (event.type) {
         case ENET_EVENT_TYPE_CONNECT:
@@ -157,6 +196,7 @@ void NetworkClient::Update() {
             m_connected = false;
             m_connecting = false;
             m_serverPeer = nullptr;
+            // Don't touch event.peer — ENet has already invalidated it.
             break;
 
         default:

--- a/KenshiMP.Core/net/packet_handler.cpp
+++ b/KenshiMP.Core/net/packet_handler.cpp
@@ -113,8 +113,23 @@ public:
     static void Initialize() {
         Core::Get().GetClient().SetPacketCallback(
             [](const uint8_t* data, size_t size, int channel) {
-                HandlePacket(data, size, channel);
+                // SEH-guard the whole dispatch. The game runs Update() on its
+                // main thread; if a malformed packet ever triggers a fault
+                // inside a deserializer we still want the game to keep
+                // running (the player can disconnect and reconnect). MSVC
+                // forbids __try in a function with C++ unwind, so the
+                // dispatch lives in its own thunk. (#69)
+                SafeHandlePacket(data, size, channel);
             });
+    }
+
+    static void SafeHandlePacket(const uint8_t* data, size_t size, int channel) {
+        __try {
+            HandlePacket(data, size, channel);
+        } __except (EXCEPTION_EXECUTE_HANDLER) {
+            spdlog::error("PacketHandler: SEH caught exception during dispatch "
+                          "(channel={} size={})", channel, size);
+        }
     }
 
     // ── All Players Ready (Server → Client) ──

--- a/KenshiMP.Injector/injector.cpp
+++ b/KenshiMP.Injector/injector.cpp
@@ -25,6 +25,8 @@ bool InstallOgrePlugin(const std::wstring& gamePath) {
     while (std::getline(inFile, line)) {
         // Remove trailing CR if present
         if (!line.empty() && line.back() == '\r') line.pop_back();
+        // Skip blank lines created by repeated patching
+        if (line.empty()) continue;
 
         if (line == PLUGIN_LINE) {
             alreadyInstalled = true;
@@ -35,16 +37,19 @@ bool InstallOgrePlugin(const std::wstring& gamePath) {
 
     if (alreadyInstalled) return true; // Already installed
 
-    // Add our plugin line
+    // Add our plugin line. We always write with a trailing newline so that the
+    // next tool to append doesn't merge two plugin lines into one (which
+    // produces e.g. `Plugin=RenderSystem_Direct3D11Plugin=KenshiMP.Core` and
+    // crashes Ogre on launch — Kenshi simply fails to start, see issues #64 #72).
     lines.push_back(PLUGIN_LINE);
 
-    // Write back
-    std::ofstream outFile(cfgPath);
+    // Write back with consistent CRLF line endings (Kenshi's existing file uses
+    // CRLF on Windows; matching avoids touching the user's diff unnecessarily).
+    std::ofstream outFile(cfgPath, std::ios::binary);
     if (!outFile.is_open()) return false;
 
     for (size_t i = 0; i < lines.size(); i++) {
-        outFile << lines[i];
-        if (i + 1 < lines.size()) outFile << "\n";
+        outFile << lines[i] << "\r\n";
     }
     outFile.close();
 
@@ -68,12 +73,11 @@ bool RemoveOgrePlugin(const std::wstring& gamePath) {
     }
     inFile.close();
 
-    std::ofstream outFile(cfgPath);
+    std::ofstream outFile(cfgPath, std::ios::binary);
     if (!outFile.is_open()) return false;
 
     for (size_t i = 0; i < lines.size(); i++) {
-        outFile << lines[i];
-        if (i + 1 < lines.size()) outFile << "\n";
+        outFile << lines[i] << "\r\n";
     }
     outFile.close();
 

--- a/KenshiMP.Scanner/include/kmp/memory.h
+++ b/KenshiMP.Scanner/include/kmp/memory.h
@@ -7,9 +7,22 @@ namespace kmp {
 
 class Memory {
 public:
+    // Cheap pre-check that rejects pointers which cannot possibly be valid
+    // user-mode x64 addresses. This avoids triggering SEH on the most common
+    // bad-pointer cases (NULL, freed-pointer-poison values, kernel addrs).
+    // SEH still catches anything that slips through.
+    static bool IsValidPointer(uintptr_t addr) {
+        // Anything below 0x10000 is in the NULL guard region.
+        if (addr < 0x10000) return false;
+        // User-mode x64 addresses are bounded to the 48-bit canonical range.
+        if (addr >= 0x00007FFFFFFFFFFFULL) return false;
+        return true;
+    }
+
     // Safe read from game memory (handles access violations)
     template<typename T>
     static bool Read(uintptr_t address, T& out) {
+        if (!IsValidPointer(address)) return false;
         __try {
             out = *reinterpret_cast<T*>(address);
             return true;
@@ -21,6 +34,7 @@ public:
     // Safe write to game memory
     template<typename T>
     static bool Write(uintptr_t address, const T& value) {
+        if (!IsValidPointer(address)) return false;
         DWORD oldProtect;
         if (!VirtualProtect(reinterpret_cast<void*>(address), sizeof(T),
                            PAGE_EXECUTE_READWRITE, &oldProtect)) {

--- a/KenshiMP.Server/CMakeLists.txt
+++ b/KenshiMP.Server/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_executable(KenshiMP.Server
     main.cpp
     server.cpp
+    authority_validator.cpp
     upnp.cpp
     game_state.cpp
     player_manager.cpp

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ```bash
 # 1. Clone
-git clone https://github.com/The404Studios/Kenshi-Online.git
+git clone --recursive https://github.com/The404Studios/Kenshi-Online.git
 cd Kenshi-Online
 
 # 2. Build

--- a/README.md
+++ b/README.md
@@ -13,22 +13,45 @@
 
 ## 🚀 Quick Start
 
-```bash
-# 1. Clone
-git clone --recursive https://github.com/The404Studios/Kenshi-Online.git
-cd Kenshi-Online
+### 1. Download
 
-# 2. Build
-cd build
-MSBuild.exe KenshiMP.sln /p:Configuration=Release /p:Platform=x64 /m
+Download the current Windows prerelease:
 
-# 3. Install
-copy bin\Release\KenshiMP.Core.dll "C:\Program Files (x86)\Steam\steamapps\common\Kenshi\"
-# Edit Kenshi/data/Plugins_x64.cfg, add: Plugin=../KenshiMP.Core
+- [KenshiMP v0.3.0-alpha-installer.2](https://github.com/Dedstate/Kenshi-Online/releases/tag/v0.3.0-alpha-installer.2)
+- [Direct download: KenshiMP-Install.zip](https://github.com/Dedstate/Kenshi-Online/releases/download/v0.3.0-alpha-installer.2/KenshiMP-Install.zip)
+- [SHA-256 checksums](https://github.com/Dedstate/Kenshi-Online/releases/download/v0.3.0-alpha-installer.2/SHA256SUMS.txt)
 
-# 4. Launch
-KenshiMP.Injector.exe
-```
+Extract the entire ZIP into a separate folder. Do not run the installer from
+inside the archive.
+
+### 2. Install
+
+1. Close Kenshi if it is running.
+2. Run `install.bat` from the extracted folder.
+3. The installer detects the standard Steam and GOG locations. If Kenshi is
+   installed elsewhere, enter the folder containing `kenshi_x64.exe`.
+4. If Windows denies write access to the Kenshi folder, run `install.bat` as
+   Administrator.
+5. Wait for `KenshiMP installation completed and verified`.
+
+The installer copies the plugin, server, UI layouts and multiplayer mod; adds
+`Plugin=KenshiMP.Core` to `Plugins_x64.cfg`; enables `kenshi-online` in the mod
+list; and stores backups in `<Kenshi>\.KenshiMP-install-state`.
+
+### 3. Connect
+
+The quickest method is the included launcher:
+
+1. Run `KenshiMP.Injector.exe` from the extracted folder.
+2. Confirm the Kenshi path.
+3. Enter your player name, server IP address and port (`27800` by default).
+4. Click **PLAY**.
+5. Load or start a game. The launcher enables auto-connect, so synchronization
+   begins after the world is loaded.
+
+You can also launch Kenshi normally, open **MULTIPLAYER → JOIN GAME**, enter the
+same address, port and player name, then click **CONNECT**. Press **F1** to open
+or close the multiplayer menu while in game.
 
 ---
 
@@ -110,23 +133,43 @@ MSBuild.exe KenshiMP.sln /p:Configuration=Release /p:Platform=x64 /m
 ## 🎮 How to Play
 
 ### Client
-1. Launch via `KenshiMP.Injector.exe`
-2. Load your save
-3. Press **F1** → enter server IP/port
-4. Click "Connect"
-5. Wait for "All players ready"
+
+1. Install the complete release package with `install.bat`.
+2. Launch through `KenshiMP.Injector.exe` for automatic connection, or launch
+   Kenshi normally and use **MULTIPLAYER → JOIN GAME**.
+3. Enter the host IP, UDP port and your player name.
+4. Click **CONNECT**, then load or start the world if it is not already loaded.
+5. Wait for the connection/synchronization message before playing.
+
+For a server on the same PC use `127.0.0.1:27800`. For LAN use the host's local
+IP address. For Internet play use its public IP or DNS name; the host must allow
+UDP traffic on the configured port.
 
 ### Server
-1. Edit `server.json`:
+
+1. Edit `server.json` next to `KenshiMP.Server.exe`:
    ```json
    {
      "serverName": "My Server",
-     "port": 7777,
+     "port": 27800,
      "maxPlayers": 16
    }
    ```
-2. Run `KenshiMP.Server.exe`
-3. Forward UDP port 7777
+2. Run `KenshiMP.Server.exe`, or use **MULTIPLAYER → HOST GAME**.
+3. Allow `KenshiMP.Server.exe` through Windows Firewall.
+4. For Internet hosting, forward UDP port `27800` to the server PC if UPnP does
+   not configure the router automatically.
+
+The server must remain running while clients are connected. If you change the
+`port` value, every client must use the same port.
+
+### Updating and uninstalling
+
+- To update, extract the newer complete ZIP and run its `install.bat` again.
+  Existing original backups are preserved.
+- To remove KenshiMP safely, run `uninstall.bat` from the same release package.
+- Do not delete `<Kenshi>\.KenshiMP-install-state` before uninstalling; it
+  contains the information needed to restore the original files.
 
 ---
 
@@ -179,13 +222,13 @@ MIT License - See [LICENSE](LICENSE)
 
 ## 📞 Contact
 
-- **GitHub:** [The404Studios/Kenshi-Online](https://github.com/The404Studios/Kenshi-Online)
-- **Issues:** [Report bugs](https://github.com/The404Studios/Kenshi-Online/issues)
+- **GitHub:** [Dedstate/Kenshi-Online](https://github.com/Dedstate/Kenshi-Online)
+- **Issues:** [Report bugs](https://github.com/Dedstate/Kenshi-Online/issues)
 - **Email:** the404studios@gmail.com
 
 ---
 
-**Last Updated:** 2026-06-04 | **Version:** 0.3.0-alpha | **Status:** ✅ Functional
+**Last Updated:** 2026-07-14 | **Version:** v0.3.0-alpha-installer.2 | **Status:** Prerelease
 
 <p align="center">
   <strong>Built with 🧠 by Claude AI and ❤️ by The404Studios</strong>

--- a/build.bat
+++ b/build.bat
@@ -30,9 +30,21 @@ if exist "%ProgramFiles%\Microsoft Visual Studio\2022" (
     goto :fail
 )
 
-:: ── Check submodules ──
-if not exist "lib\enet\CMakeLists.txt" (
-    echo [WARN] Submodules not initialized. Running git submodule update...
+:: ── Check required submodules ──
+set "NEED_SUBMODULES="
+if not exist "lib\enet\CMakeLists.txt" set "NEED_SUBMODULES=1"
+if not exist "lib\minhook\CMakeLists.txt" set "NEED_SUBMODULES=1"
+if not exist "lib\spdlog\CMakeLists.txt" set "NEED_SUBMODULES=1"
+if not exist "lib\json\CMakeLists.txt" set "NEED_SUBMODULES=1"
+
+if defined NEED_SUBMODULES (
+    echo [WARN] Required submodules are not initialized. Running git submodule update...
+    where git >nul 2>&1
+    if errorlevel 1 (
+        echo [ERROR] Git not found in PATH.
+        echo         Install Git or clone the repository with --recursive.
+        goto :fail
+    )
     git submodule update --init --recursive
     if errorlevel 1 (
         echo [ERROR] Failed to initialize submodules.
@@ -40,6 +52,25 @@ if not exist "lib\enet\CMakeLists.txt" (
         goto :fail
     )
 )
+
+set "MISSING_DEPENDENCIES="
+if not exist "lib\enet\CMakeLists.txt" (
+    echo [ERROR] Missing dependency: lib\enet
+    set "MISSING_DEPENDENCIES=1"
+)
+if not exist "lib\minhook\CMakeLists.txt" (
+    echo [ERROR] Missing dependency: lib\minhook
+    set "MISSING_DEPENDENCIES=1"
+)
+if not exist "lib\spdlog\CMakeLists.txt" (
+    echo [ERROR] Missing dependency: lib\spdlog
+    set "MISSING_DEPENDENCIES=1"
+)
+if not exist "lib\json\CMakeLists.txt" (
+    echo [ERROR] Missing dependency: lib\json
+    set "MISSING_DEPENDENCIES=1"
+)
+if defined MISSING_DEPENDENCIES goto :fail
 
 :: ── Configure ──
 echo.

--- a/dist/install.bat
+++ b/dist/install.bat
@@ -1,245 +1,386 @@
 @echo off
-setlocal enabledelayedexpansion
+setlocal EnableExtensions DisableDelayedExpansion
 title KenshiMP Installer
 color 0A
+
+set "EXIT_CODE=0"
+set "QUIET=0"
+set "FIRST_INSTALL=0"
+if /I "%~2"=="/quiet" set "QUIET=1"
 
 echo.
 echo  ============================================
 echo   KenshiMP - Kenshi Multiplayer Mod
-echo   One-Click Installer
-echo   made with love by fourzerofour
+echo   Safe Windows Installer
 echo  ============================================
 echo.
 
-:: ── Auto-detect Kenshi directory ──
-:: Try common locations, then fall back to asking
+set "KENSHI_DIR=%~1"
+if defined KENSHI_DIR goto :validate_kenshi
 
-set "KENSHI_DIR="
+if exist "%~dp0kenshi_x64.exe" set "KENSHI_DIR=%~dp0"
+if defined KENSHI_DIR goto :validate_kenshi
+if exist "%~dp0..\kenshi_x64.exe" set "KENSHI_DIR=%~dp0.."
+if defined KENSHI_DIR goto :validate_kenshi
+if exist "C:\Program Files (x86)\Steam\steamapps\common\Kenshi\kenshi_x64.exe" set "KENSHI_DIR=C:\Program Files (x86)\Steam\steamapps\common\Kenshi"
+if defined KENSHI_DIR goto :validate_kenshi
+if exist "C:\GOG Games\Kenshi\kenshi_x64.exe" set "KENSHI_DIR=C:\GOG Games\Kenshi"
+if defined KENSHI_DIR goto :validate_kenshi
 
-:: Check if we're already in the Kenshi folder
-if exist "%~dp0kenshi_x64.exe" (
-    set "KENSHI_DIR=%~dp0"
-    goto :found_kenshi
+if "%QUIET%"=="1" (
+    echo  [ERROR] Kenshi was not found and interactive prompting is disabled.
+    goto :invalid_kenshi
 )
 
-:: Check if we're in a subfolder of Kenshi
-if exist "%~dp0..\kenshi_x64.exe" (
-    set "KENSHI_DIR=%~dp0..\"
-    goto :found_kenshi
-)
-
-:: Try Steam default location
-set "STEAM_KENSHI=C:\Program Files (x86)\Steam\steamapps\common\Kenshi"
-if exist "%STEAM_KENSHI%\kenshi_x64.exe" (
-    set "KENSHI_DIR=%STEAM_KENSHI%"
-    goto :found_kenshi
-)
-
-:: Try GOG default
-set "GOG_KENSHI=C:\GOG Games\Kenshi"
-if exist "%GOG_KENSHI%\kenshi_x64.exe" (
-    set "KENSHI_DIR=%GOG_KENSHI%"
-    goto :found_kenshi
-)
-
-:: Ask user
-echo  Could not auto-detect Kenshi installation.
-echo  Please enter the path to your Kenshi folder:
-echo  (The folder containing kenshi_x64.exe)
-echo.
+echo  Kenshi could not be auto-detected.
+echo  Enter the folder containing kenshi_x64.exe.
 set /p "KENSHI_DIR=Path: "
 
+:validate_kenshi
+if not defined KENSHI_DIR goto :invalid_kenshi
+for %%I in ("%KENSHI_DIR%") do set "KENSHI_DIR=%%~fI"
 if not exist "%KENSHI_DIR%\kenshi_x64.exe" (
-    echo.
-    echo  [ERROR] kenshi_x64.exe not found at: %KENSHI_DIR%
-    echo  Make sure you entered the correct Kenshi folder.
-    echo.
-    pause
-    exit /b 1
+    echo  [ERROR] kenshi_x64.exe was not found in:
+    echo          "%KENSHI_DIR%"
+    echo          Select the Kenshi installation directory, not a subdirectory.
+    goto :invalid_kenshi
+)
+if not exist "%KENSHI_DIR%\data\gui\layout" (
+    echo  [ERROR] Required Kenshi layout directory is missing:
+    echo          "%KENSHI_DIR%\data\gui\layout"
+    goto :invalid_kenshi
+)
+if not exist "%KENSHI_DIR%\Plugins_x64.cfg" (
+    echo  [ERROR] Required Kenshi file is missing: Plugins_x64.cfg
+    goto :invalid_kenshi
+)
+if not exist "%KENSHI_DIR%\data\gui\layout\Kenshi_MainMenu.layout" (
+    echo  [ERROR] Required Kenshi file is missing: Kenshi_MainMenu.layout
+    goto :invalid_kenshi
+)
+if not exist "%KENSHI_DIR%\mods" (
+    echo  [ERROR] Required Kenshi mods directory is missing:
+    echo          "%KENSHI_DIR%\mods"
+    goto :invalid_kenshi
 )
 
-:found_kenshi
-:: Remove trailing backslash if present
-if "%KENSHI_DIR:~-1%"=="\" set "KENSHI_DIR=%KENSHI_DIR:~0,-1%"
-
-echo  Found Kenshi at: %KENSHI_DIR%
+echo  Found Kenshi at: "%KENSHI_DIR%"
 echo.
 
-:: ── Check if Kenshi is running ──
+echo  [1/6] Validating release package...
+call :require_file "%~dp0KenshiMP.Core.dll" "KenshiMP.Core.dll" 65536
+if errorlevel 1 goto :invalid_package
+call :require_file "%~dp0KenshiMP.Server.exe" "KenshiMP.Server.exe" 1
+if errorlevel 1 goto :invalid_package
+call :require_file "%~dp0Kenshi_MainMenu.layout" "Kenshi_MainMenu.layout" 1
+if errorlevel 1 goto :invalid_package
+call :require_file "%~dp0Kenshi_MultiplayerHUD.layout" "Kenshi_MultiplayerHUD.layout" 1
+if errorlevel 1 goto :invalid_package
+call :require_file "%~dp0Kenshi_MultiplayerPanel.layout" "Kenshi_MultiplayerPanel.layout" 1
+if errorlevel 1 goto :invalid_package
+call :require_file "%~dp0kenshi-online.mod" "kenshi-online.mod" 1
+if errorlevel 1 goto :invalid_package
+call :require_file "%~dp0server.json" "server.json" 1
+if errorlevel 1 goto :invalid_package
+echo         All required package files are present.
+
 tasklist /FI "IMAGENAME eq kenshi_x64.exe" 2>NUL | find /I "kenshi_x64.exe" >NUL
-if %errorlevel% equ 0 (
-    echo  [WARNING] Kenshi is currently running!
-    echo  Please close Kenshi before installing.
-    echo.
-    pause
-    exit /b 1
+if not errorlevel 1 (
+    echo  [ERROR] Kenshi is running. Close it before installing.
+    set "EXIT_CODE=3"
+    goto :finish
 )
 
-:: ── Create backups ──
-echo  [1/5] Creating backups...
+echo  [2/6] Checking write access...
+call :probe_directory "%KENSHI_DIR%"
+if errorlevel 1 goto :permission_error
+call :probe_directory "%KENSHI_DIR%\data"
+if errorlevel 1 goto :permission_error
+call :probe_directory "%KENSHI_DIR%\data\gui\layout"
+if errorlevel 1 goto :permission_error
+call :probe_directory "%KENSHI_DIR%\mods"
+if errorlevel 1 goto :permission_error
+call :probe_file "%KENSHI_DIR%\KenshiMP.Core.dll"
+if errorlevel 1 goto :permission_error
+call :probe_file "%KENSHI_DIR%\KenshiMP.Server.exe"
+if errorlevel 1 goto :permission_error
+call :probe_file "%KENSHI_DIR%\server.json"
+if errorlevel 1 goto :permission_error
+call :probe_file "%KENSHI_DIR%\Plugins_x64.cfg"
+if errorlevel 1 goto :permission_error
+call :probe_file "%KENSHI_DIR%\data\gui\layout\Kenshi_MainMenu.layout"
+if errorlevel 1 goto :permission_error
+call :probe_file "%KENSHI_DIR%\data\gui\layout\Kenshi_MultiplayerPanel.layout"
+if errorlevel 1 goto :permission_error
+call :probe_file "%KENSHI_DIR%\data\gui\layout\Kenshi_MultiplayerHUD.layout"
+if errorlevel 1 goto :permission_error
+call :probe_file "%KENSHI_DIR%\data\kenshi-online.mod"
+if errorlevel 1 goto :permission_error
+call :probe_file "%KENSHI_DIR%\mods\kenshi-online\kenshi-online.mod"
+if errorlevel 1 goto :permission_error
+call :probe_file "%KENSHI_DIR%\data\__mods.list"
+if errorlevel 1 goto :permission_error
+echo         Required locations are writable.
 
-set "BACKUP_DIR=%KENSHI_DIR%\KenshiMP_backup"
-if not exist "%BACKUP_DIR%" mkdir "%BACKUP_DIR%"
-
-if exist "%KENSHI_DIR%\Plugins_x64.cfg" (
-    if not exist "%BACKUP_DIR%\Plugins_x64.cfg.bak" (
-        copy /Y "%KENSHI_DIR%\Plugins_x64.cfg" "%BACKUP_DIR%\Plugins_x64.cfg.bak" >nul
-        echo         Backed up Plugins_x64.cfg
-    )
+set "STATE_DIR=%KENSHI_DIR%\.KenshiMP-install-state"
+if exist "%STATE_DIR%\installed.marker" (
+    findstr /X /C:"KenshiMP managed installation v1" "%STATE_DIR%\installed.marker" >NUL 2>&1
+    if errorlevel 1 goto :unsafe_state
+    call :validate_state
+    if errorlevel 1 goto :unsafe_state
+    set "FIRST_INSTALL=0"
+    echo  [3/6] Existing managed installation found; preserving original backups.
+    goto :install_files
+)
+if exist "%STATE_DIR%" (
+    echo  [ERROR] Unsafe or incomplete installer state exists:
+    echo          "%STATE_DIR%"
+    echo          Move it aside after inspecting it, then run the installer again.
+    set "EXIT_CODE=4"
+    goto :finish
 )
 
-if exist "%KENSHI_DIR%\data\gui\layout\Kenshi_MainMenu.layout" (
-    if not exist "%BACKUP_DIR%\Kenshi_MainMenu.layout.bak" (
-        copy /Y "%KENSHI_DIR%\data\gui\layout\Kenshi_MainMenu.layout" "%BACKUP_DIR%\Kenshi_MainMenu.layout.bak" >nul
-        echo         Backed up Kenshi_MainMenu.layout
-    )
-)
+echo  [3/6] Recording original files...
+mkdir "%STATE_DIR%" >NUL 2>&1
+if errorlevel 1 goto :permission_error
+>"%STATE_DIR%\transaction.marker" echo KenshiMP installer transaction v1
+if not exist "%STATE_DIR%\transaction.marker" goto :permission_error
+set "FIRST_INSTALL=1"
 
-:: ── Copy DLL ──
-echo  [2/5] Installing KenshiMP.Core.dll...
+call :capture_original "%KENSHI_DIR%\KenshiMP.Core.dll" "core"
+if errorlevel 1 goto :install_failed
+call :capture_original "%KENSHI_DIR%\KenshiMP.Server.exe" "server"
+if errorlevel 1 goto :install_failed
+call :capture_original "%KENSHI_DIR%\server.json" "server-config"
+if errorlevel 1 goto :install_failed
+call :capture_original "%KENSHI_DIR%\Plugins_x64.cfg" "plugins-config"
+if errorlevel 1 goto :install_failed
+call :capture_original "%KENSHI_DIR%\data\gui\layout\Kenshi_MainMenu.layout" "main-menu"
+if errorlevel 1 goto :install_failed
+call :capture_original "%KENSHI_DIR%\data\gui\layout\Kenshi_MultiplayerPanel.layout" "panel-layout"
+if errorlevel 1 goto :install_failed
+call :capture_original "%KENSHI_DIR%\data\gui\layout\Kenshi_MultiplayerHUD.layout" "hud-layout"
+if errorlevel 1 goto :install_failed
+call :capture_original "%KENSHI_DIR%\data\kenshi-online.mod" "data-mod"
+if errorlevel 1 goto :install_failed
+call :capture_original "%KENSHI_DIR%\mods\kenshi-online\kenshi-online.mod" "folder-mod"
+if errorlevel 1 goto :install_failed
+call :capture_original "%KENSHI_DIR%\data\__mods.list" "mods-list"
+if errorlevel 1 goto :install_failed
 
-if exist "%~dp0KenshiMP.Core.dll" (
-    copy /Y "%~dp0KenshiMP.Core.dll" "%KENSHI_DIR%\KenshiMP.Core.dll" >nul
-    if errorlevel 1 (
-        echo  [ERROR] Failed to copy DLL. Is Kenshi running?
-        pause
-        exit /b 1
-    )
-    echo         Copied KenshiMP.Core.dll
-) else (
-    echo  [ERROR] KenshiMP.Core.dll not found in installer folder!
-    pause
-    exit /b 1
-)
+:install_files
+echo  [4/6] Installing package-owned files...
+if not exist "%KENSHI_DIR%\mods\kenshi-online" mkdir "%KENSHI_DIR%\mods\kenshi-online" >NUL 2>&1
+if not exist "%KENSHI_DIR%\mods\kenshi-online" goto :install_failed
 
-:: ── Patch Plugins_x64.cfg ──
-echo  [3/5] Patching Plugins_x64.cfg...
+call :copy_required "%~dp0KenshiMP.Core.dll" "%KENSHI_DIR%\KenshiMP.Core.dll"
+if errorlevel 1 goto :install_failed
+call :copy_required "%~dp0KenshiMP.Server.exe" "%KENSHI_DIR%\KenshiMP.Server.exe"
+if errorlevel 1 goto :install_failed
+call :copy_required "%~dp0server.json" "%KENSHI_DIR%\server.json"
+if errorlevel 1 goto :install_failed
+call :copy_required "%~dp0Kenshi_MainMenu.layout" "%KENSHI_DIR%\data\gui\layout\Kenshi_MainMenu.layout"
+if errorlevel 1 goto :install_failed
+call :copy_required "%~dp0Kenshi_MultiplayerPanel.layout" "%KENSHI_DIR%\data\gui\layout\Kenshi_MultiplayerPanel.layout"
+if errorlevel 1 goto :install_failed
+call :copy_required "%~dp0Kenshi_MultiplayerHUD.layout" "%KENSHI_DIR%\data\gui\layout\Kenshi_MultiplayerHUD.layout"
+if errorlevel 1 goto :install_failed
+call :copy_required "%~dp0kenshi-online.mod" "%KENSHI_DIR%\data\kenshi-online.mod"
+if errorlevel 1 goto :install_failed
+call :copy_required "%~dp0kenshi-online.mod" "%KENSHI_DIR%\mods\kenshi-online\kenshi-online.mod"
+if errorlevel 1 goto :install_failed
 
-findstr /C:"Plugin=KenshiMP.Core" "%KENSHI_DIR%\Plugins_x64.cfg" >nul 2>&1
+echo  [5/6] Updating Kenshi configuration...
+findstr /X /C:"Plugin=KenshiMP.Core" "%KENSHI_DIR%\Plugins_x64.cfg" >NUL 2>&1
 if errorlevel 1 (
-    echo Plugin=KenshiMP.Core>> "%KENSHI_DIR%\Plugins_x64.cfg"
-    echo         Added KenshiMP.Core plugin entry
-) else (
-    echo         Plugin entry already exists
+    >>"%KENSHI_DIR%\Plugins_x64.cfg" echo Plugin=KenshiMP.Core
 )
-
-:: ── Patch Main Menu Layout ──
-echo  [4/5] Patching main menu layout...
-
-findstr /C:"MultiplayerButton" "%KENSHI_DIR%\data\gui\layout\Kenshi_MainMenu.layout" >nul 2>&1
+if not exist "%KENSHI_DIR%\data\__mods.list" type NUL >"%KENSHI_DIR%\data\__mods.list"
+findstr /X /C:"kenshi-online" "%KENSHI_DIR%\data\__mods.list" >NUL 2>&1
 if errorlevel 1 (
-    echo         Adding MULTIPLAYER button to main menu...
-
-    :: We need to insert the button before the OPTIONS button.
-    :: The OPTIONS button has name="OptionsButton".
-    :: We'll use PowerShell for reliable XML insertion.
-
-    powershell -NoProfile -ExecutionPolicy Bypass -Command ^
-        "$file = '%KENSHI_DIR%\data\gui\layout\Kenshi_MainMenu.layout';" ^
-        "$content = Get-Content $file -Raw;" ^
-        "$mpButton = @'" ^
-"            <Widget type=\""Button\"" skin=\""Kenshi_Button1\"" position_real=\""0.260417 0.582407 0.15625 0.0638889\"" name=\""MultiplayerButton\"">`n" ^
-"                <Property key=\""Caption\"" value=\""MULTIPLAYER\""/>`n" ^
-"                <Property key=\""FontName\"" value=\""Kenshi_PaintedTextFont_Large\""/>`n" ^
-"            </Widget>`n" ^
-"'@;" ^
-        "if ($content -match 'OptionsButton') {" ^
-        "  $optLine = '            <Widget type=\"\"Button\"\" skin=\"\"Kenshi_Button1\"\".*name=\"\"OptionsButton\"\"';" ^
-        "  $content = $content -replace '(?m)(^\s*<Widget[^>]+name=\"\"OptionsButton\"\")', ($mpButton + \"`n`$1\");" ^
-        "  Set-Content $file $content -NoNewline;" ^
-        "  Write-Host '        MULTIPLAYER button added';" ^
-        "} else {" ^
-        "  Write-Host '        [WARNING] Could not find OptionsButton anchor';" ^
-        "}"
-
-    if errorlevel 1 (
-        echo         [WARNING] Auto-patch failed. Copying pre-patched layout...
-        if exist "%~dp0Kenshi_MainMenu.layout" (
-            copy /Y "%~dp0Kenshi_MainMenu.layout" "%KENSHI_DIR%\data\gui\layout\Kenshi_MainMenu.layout" >nul
-            echo         Copied pre-patched Kenshi_MainMenu.layout
-        )
-    )
-) else (
-    echo         MULTIPLAYER button already present
+    >>"%KENSHI_DIR%\data\__mods.list" echo kenshi-online
 )
 
-:: ── Copy Multiplayer Layouts ──
-echo  [5/6] Installing multiplayer layouts...
+echo  [6/6] Verifying installation...
+for %%F in (
+    "%KENSHI_DIR%\KenshiMP.Core.dll"
+    "%KENSHI_DIR%\KenshiMP.Server.exe"
+    "%KENSHI_DIR%\server.json"
+    "%KENSHI_DIR%\data\gui\layout\Kenshi_MainMenu.layout"
+    "%KENSHI_DIR%\data\gui\layout\Kenshi_MultiplayerPanel.layout"
+    "%KENSHI_DIR%\data\gui\layout\Kenshi_MultiplayerHUD.layout"
+    "%KENSHI_DIR%\data\kenshi-online.mod"
+    "%KENSHI_DIR%\mods\kenshi-online\kenshi-online.mod"
+) do if not exist "%%~fF" goto :verification_failed
+findstr /X /C:"Plugin=KenshiMP.Core" "%KENSHI_DIR%\Plugins_x64.cfg" >NUL 2>&1
+if errorlevel 1 goto :verification_failed
+findstr /X /C:"kenshi-online" "%KENSHI_DIR%\data\__mods.list" >NUL 2>&1
+if errorlevel 1 goto :verification_failed
 
-if exist "%~dp0Kenshi_MultiplayerPanel.layout" (
-    copy /Y "%~dp0Kenshi_MultiplayerPanel.layout" "%KENSHI_DIR%\data\gui\layout\Kenshi_MultiplayerPanel.layout" >nul
-    echo         Copied Kenshi_MultiplayerPanel.layout
+if "%FIRST_INSTALL%"=="1" (
+    >"%STATE_DIR%\installed.marker" echo KenshiMP managed installation v1
+    if not exist "%STATE_DIR%\installed.marker" goto :install_failed
+    del /F /Q "%STATE_DIR%\transaction.marker" >NUL 2>&1
+)
+
+echo.
+echo  [OK] KenshiMP installation completed and verified.
+echo       Original files are recorded in:
+echo       "%STATE_DIR%"
+set "EXIT_CODE=0"
+goto :finish
+
+:invalid_kenshi
+set "EXIT_CODE=1"
+goto :finish
+
+:invalid_package
+echo  [ERROR] The release package is incomplete or contains an invalid file.
+echo          Extract the complete KenshiMP-Install.zip and try again.
+set "EXIT_CODE=2"
+goto :finish
+
+:permission_error
+echo  [ERROR] Kenshi files are not writable.
+echo          Run this installer with permission to modify the Kenshi directory.
+set "EXIT_CODE=3"
+goto :finish
+
+:unsafe_state
+echo  [ERROR] KenshiMP installer state is incomplete or unrecognized:
+echo          "%STATE_DIR%"
+echo          No Kenshi files were changed. Inspect or move the state directory.
+set "EXIT_CODE=4"
+goto :finish
+
+:verification_failed
+echo  [ERROR] Post-install verification failed.
+goto :install_failed
+
+:install_failed
+echo  [ERROR] Installation failed while updating Kenshi files.
+if "%FIRST_INSTALL%"=="1" (
+    echo          Rolling back this first installation...
+    call :rollback_first_install
 ) else (
-    echo  [ERROR] Kenshi_MultiplayerPanel.layout not found in installer folder!
-    pause
+    echo          Original backups were preserved. Re-run the installer or uninstall safely.
+)
+set "EXIT_CODE=4"
+goto :finish
+
+:require_file
+if not exist "%~1" (
+    echo  [ERROR] Missing required package file: %~2
     exit /b 1
 )
-
-if exist "%~dp0Kenshi_MultiplayerHUD.layout" (
-    copy /Y "%~dp0Kenshi_MultiplayerHUD.layout" "%KENSHI_DIR%\data\gui\layout\Kenshi_MultiplayerHUD.layout" >nul
-    echo         Copied Kenshi_MultiplayerHUD.layout
-) else (
-    echo  [WARNING] Kenshi_MultiplayerHUD.layout not found (in-game HUD may not work)
+for %%F in ("%~1") do if %%~zF LSS %~3 (
+    echo  [ERROR] Required package file is too small: %~2 ^(%%~zF bytes^)
+    exit /b 1
 )
+exit /b 0
 
-:: ── Install Multiplayer Mod ──
-echo  [6/7] Installing kenshi-online.mod...
+:probe_directory
+set "PROBE_FILE=%~1\.kenshimp-write-test-%RANDOM%-%RANDOM%.tmp"
+>"%PROBE_FILE%" echo write-test
+if not exist "%PROBE_FILE%" exit /b 1
+del /F /Q "%PROBE_FILE%" >NUL 2>&1
+if exist "%PROBE_FILE%" exit /b 1
+exit /b 0
 
-if exist "%~dp0kenshi-online.mod" (
-    :: Copy to data/ (always loaded by the game engine)
-    copy /Y "%~dp0kenshi-online.mod" "%KENSHI_DIR%\data\kenshi-online.mod" >nul
-    echo         Copied kenshi-online.mod to data/
+:probe_file
+if not exist "%~1" exit /b 0
+set "KMP_PROBE_FILE=%~1"
+powershell -NoProfile -ExecutionPolicy Bypass -Command "try { $stream = [IO.File]::Open($env:KMP_PROBE_FILE, 'Open', 'Write', 'ReadWrite'); $stream.Dispose(); exit 0 } catch { exit 1 }" >NUL 2>&1
+exit /b %ERRORLEVEL%
 
-    :: Also copy to mods/kenshi-online/ (standard mod location)
-    if not exist "%KENSHI_DIR%\mods\kenshi-online" mkdir "%KENSHI_DIR%\mods\kenshi-online"
-    copy /Y "%~dp0kenshi-online.mod" "%KENSHI_DIR%\mods\kenshi-online\kenshi-online.mod" >nul
-    echo         Copied kenshi-online.mod to mods/
-
-    :: Add to __mods.list if not present
-    findstr /C:"kenshi-online" "%KENSHI_DIR%\data\__mods.list" >nul 2>&1
-    if errorlevel 1 (
-        echo kenshi-online>> "%KENSHI_DIR%\data\__mods.list"
-        echo         Added kenshi-online to mod load list
-    ) else (
-        echo         kenshi-online already in mod load list
-    )
+:capture_original
+if exist "%~1" (
+    copy /B /Y "%~1" "%STATE_DIR%\%~2.bak" >NUL 2>&1
+    if errorlevel 1 exit /b 1
+    >"%STATE_DIR%\%~2.restore" echo restore
 ) else (
-    echo         [INFO] kenshi-online.mod not in package (mod template spawning disabled)
+    >"%STATE_DIR%\%~2.remove" echo remove
 )
+if not exist "%STATE_DIR%\%~2.restore" if not exist "%STATE_DIR%\%~2.remove" exit /b 1
+exit /b 0
 
-:: ── Copy Server ──
-echo  [7/7] Installing dedicated server...
-
-if exist "%~dp0KenshiMP.Server.exe" (
-    copy /Y "%~dp0KenshiMP.Server.exe" "%KENSHI_DIR%\KenshiMP.Server.exe" >nul
-    echo         Copied KenshiMP.Server.exe
-) else (
-    echo         [INFO] KenshiMP.Server.exe not in package (hosting optional)
+:validate_state
+for %%K in (core server server-config plugins-config main-menu panel-layout hud-layout data-mod folder-mod mods-list) do (
+    call :validate_state_entry "%%K"
+    if errorlevel 1 exit /b 1
 )
+exit /b 0
 
-:: ── Done ──
+:validate_state_entry
+if exist "%STATE_DIR%\%~1.restore" (
+    if exist "%STATE_DIR%\%~1.remove" exit /b 1
+    if not exist "%STATE_DIR%\%~1.bak" exit /b 1
+    exit /b 0
+)
+if exist "%STATE_DIR%\%~1.remove" exit /b 0
+exit /b 1
+
+:copy_required
+copy /B /Y "%~1" "%~2" >NUL 2>&1
+if errorlevel 1 (
+    echo  [ERROR] Could not write: "%~2"
+    exit /b 1
+)
+exit /b 0
+
+:rollback_first_install
+set "ROLLBACK_FAILED=0"
+call :restore_original "%KENSHI_DIR%\KenshiMP.Core.dll" "core"
+if errorlevel 1 set "ROLLBACK_FAILED=1"
+call :restore_original "%KENSHI_DIR%\KenshiMP.Server.exe" "server"
+if errorlevel 1 set "ROLLBACK_FAILED=1"
+call :restore_original "%KENSHI_DIR%\server.json" "server-config"
+if errorlevel 1 set "ROLLBACK_FAILED=1"
+call :restore_original "%KENSHI_DIR%\Plugins_x64.cfg" "plugins-config"
+if errorlevel 1 set "ROLLBACK_FAILED=1"
+call :restore_original "%KENSHI_DIR%\data\gui\layout\Kenshi_MainMenu.layout" "main-menu"
+if errorlevel 1 set "ROLLBACK_FAILED=1"
+call :restore_original "%KENSHI_DIR%\data\gui\layout\Kenshi_MultiplayerPanel.layout" "panel-layout"
+if errorlevel 1 set "ROLLBACK_FAILED=1"
+call :restore_original "%KENSHI_DIR%\data\gui\layout\Kenshi_MultiplayerHUD.layout" "hud-layout"
+if errorlevel 1 set "ROLLBACK_FAILED=1"
+call :restore_original "%KENSHI_DIR%\data\kenshi-online.mod" "data-mod"
+if errorlevel 1 set "ROLLBACK_FAILED=1"
+call :restore_original "%KENSHI_DIR%\mods\kenshi-online\kenshi-online.mod" "folder-mod"
+if errorlevel 1 set "ROLLBACK_FAILED=1"
+call :restore_original "%KENSHI_DIR%\data\__mods.list" "mods-list"
+if errorlevel 1 set "ROLLBACK_FAILED=1"
+if exist "%KENSHI_DIR%\mods\kenshi-online" rmdir "%KENSHI_DIR%\mods\kenshi-online" >NUL 2>&1
+if "%ROLLBACK_FAILED%"=="0" if exist "%STATE_DIR%\transaction.marker" call :remove_state_dir
+if "%ROLLBACK_FAILED%"=="0" if exist "%STATE_DIR%" set "ROLLBACK_FAILED=1"
+if "%ROLLBACK_FAILED%"=="1" echo  [ERROR] Rollback was incomplete; installer state was preserved for recovery.
+exit /b %ROLLBACK_FAILED%
+
+:restore_original
+if exist "%STATE_DIR%\%~2.restore" (
+    copy /B /Y "%STATE_DIR%\%~2.bak" "%~1" >NUL 2>&1
+    exit /b %ERRORLEVEL%
+)
+if exist "%STATE_DIR%\%~2.remove" (
+    if exist "%~1" del /F /Q "%~1" >NUL 2>&1
+    if exist "%~1" exit /b 1
+    exit /b 0
+)
+exit /b 1
+
+:remove_state_dir
+for %%K in (core server server-config plugins-config main-menu panel-layout hud-layout data-mod folder-mod mods-list) do (
+    if exist "%STATE_DIR%\%%K.bak" del /F /Q "%STATE_DIR%\%%K.bak" >NUL 2>&1
+    if exist "%STATE_DIR%\%%K.restore" del /F /Q "%STATE_DIR%\%%K.restore" >NUL 2>&1
+    if exist "%STATE_DIR%\%%K.remove" del /F /Q "%STATE_DIR%\%%K.remove" >NUL 2>&1
+)
+if exist "%STATE_DIR%\installed.marker" del /F /Q "%STATE_DIR%\installed.marker" >NUL 2>&1
+if exist "%STATE_DIR%\transaction.marker" del /F /Q "%STATE_DIR%\transaction.marker" >NUL 2>&1
+rmdir "%STATE_DIR%" >NUL 2>&1
+exit /b 0
+
+:finish
 echo.
-echo  ============================================
-echo   Installation complete!
-echo  ============================================
-echo.
-echo   TO JOIN A GAME:
-echo   1. Launch Kenshi normally
-echo   2. Click MULTIPLAYER on the main menu
-echo   3. Click JOIN GAME, enter the host's IP
-echo   4. Click CONNECT, then click NEW GAME
-echo   5. You'll auto-connect when the world loads!
-echo.
-echo   TO HOST A GAME:
-echo   1. Launch Kenshi normally
-echo   2. Click MULTIPLAYER on the main menu
-echo   3. Click HOST GAME (starts the server)
-echo   4. Port 27800 is auto-forwarded via UPnP
-echo   5. Share your IP with friends!
-echo   6. Click NEW GAME to start playing
-echo.
-echo   Default port: 27800
-echo   Backups saved to: %BACKUP_DIR%
-echo   To uninstall, run uninstall.bat
-echo.
-pause
+if not "%EXIT_CODE%"=="0" echo  Installer exit code: %EXIT_CODE%
+if "%QUIET%"=="0" pause
+exit /b %EXIT_CODE%

--- a/dist/install.bat
+++ b/dist/install.bat
@@ -95,7 +95,7 @@ if not "!MISSING_FILES!"=="" (
 if not exist "%KENSHI_DIR%\data\gui\layout" (
     echo  [WARNING] Kenshi GUI layout folder is missing.
     echo  Path: %KENSHI_DIR%\data\gui\layout
-    echo  Verify your Kenshi installation is complete (Steam: Verify integrity).
+    echo  Verify your Kenshi installation is complete ^(Steam: Verify integrity^).
     pause
     exit /b 1
 )
@@ -158,13 +158,13 @@ if errorlevel 1 (
     echo         Plugin entry already exists
 )
 
-:: ── Install Main Menu Layout (always overwrite with pre-patched copy) ──
-:: The previous version used a fragile in-place PowerShell regex insertion
-:: that often produced malformed XML on user systems. The shipped
-:: Kenshi_MainMenu.layout is a vanilla layout with the MULTIPLAYER button
-:: already in place — overwriting is reliable across Kenshi versions and
-:: locales because the layout file has not changed since FCS 1.0.
-:: The original is preserved in KenshiMP_backup\.
+rem -- Install Main Menu Layout: always overwrite with pre-patched copy --
+rem The previous version used a fragile in-place PowerShell regex insertion
+rem that often produced malformed XML on user systems. The shipped
+rem Kenshi_MainMenu.layout is a vanilla layout with the MULTIPLAYER button
+rem already in place -- overwriting is reliable across Kenshi versions and
+rem locales because the layout file has not changed since FCS 1.0.
+rem The original is preserved in KenshiMP_backup\.
 echo  [4/7] Installing main menu layout...
 
 copy /Y "%~dp0Kenshi_MainMenu.layout" "%KENSHI_DIR%\data\gui\layout\Kenshi_MainMenu.layout" >nul
@@ -250,3 +250,4 @@ echo   Backups saved to: %BACKUP_DIR%
 echo   To uninstall, run uninstall.bat
 echo.
 pause
+exit /b 0

--- a/dist/install.bat
+++ b/dist/install.bat
@@ -75,8 +75,33 @@ if %errorlevel% equ 0 (
     exit /b 1
 )
 
+:: ── Verify required files are present in the installer ──
+set "MISSING_FILES="
+if not exist "%~dp0KenshiMP.Core.dll" set "MISSING_FILES=!MISSING_FILES! KenshiMP.Core.dll"
+if not exist "%~dp0Kenshi_MainMenu.layout" set "MISSING_FILES=!MISSING_FILES! Kenshi_MainMenu.layout"
+if not exist "%~dp0Kenshi_MultiplayerPanel.layout" set "MISSING_FILES=!MISSING_FILES! Kenshi_MultiplayerPanel.layout"
+
+if not "!MISSING_FILES!"=="" (
+    echo  [ERROR] The installer package is incomplete.
+    echo  Missing files:!MISSING_FILES!
+    echo.
+    echo  Re-download the latest release from:
+    echo    https://github.com/WokiDev/Kenshi-Online/releases
+    pause
+    exit /b 1
+)
+
+:: ── Ensure required directories exist ──
+if not exist "%KENSHI_DIR%\data\gui\layout" (
+    echo  [WARNING] Kenshi GUI layout folder is missing.
+    echo  Path: %KENSHI_DIR%\data\gui\layout
+    echo  Verify your Kenshi installation is complete (Steam: Verify integrity).
+    pause
+    exit /b 1
+)
+
 :: ── Create backups ──
-echo  [1/5] Creating backups...
+echo  [1/7] Creating backups...
 
 set "BACKUP_DIR=%KENSHI_DIR%\KenshiMP_backup"
 if not exist "%BACKUP_DIR%" mkdir "%BACKUP_DIR%"
@@ -95,85 +120,71 @@ if exist "%KENSHI_DIR%\data\gui\layout\Kenshi_MainMenu.layout" (
     )
 )
 
-:: ── Copy DLL ──
-echo  [2/5] Installing KenshiMP.Core.dll...
-
-if exist "%~dp0KenshiMP.Core.dll" (
-    copy /Y "%~dp0KenshiMP.Core.dll" "%KENSHI_DIR%\KenshiMP.Core.dll" >nul
-    if errorlevel 1 (
-        echo  [ERROR] Failed to copy DLL. Is Kenshi running?
-        pause
-        exit /b 1
+if exist "%KENSHI_DIR%\data\__mods.list" (
+    if not exist "%BACKUP_DIR%\__mods.list.bak" (
+        copy /Y "%KENSHI_DIR%\data\__mods.list" "%BACKUP_DIR%\__mods.list.bak" >nul
+        echo         Backed up __mods.list
     )
-    echo         Copied KenshiMP.Core.dll
-) else (
-    echo  [ERROR] KenshiMP.Core.dll not found in installer folder!
+)
+
+:: ── Copy DLL ──
+echo  [2/7] Installing KenshiMP.Core.dll...
+
+copy /Y "%~dp0KenshiMP.Core.dll" "%KENSHI_DIR%\KenshiMP.Core.dll" >nul
+if errorlevel 1 (
+    echo  [ERROR] Failed to copy DLL. Is Kenshi running? Try running as Administrator.
     pause
     exit /b 1
 )
+echo         Copied KenshiMP.Core.dll
 
 :: ── Patch Plugins_x64.cfg ──
-echo  [3/5] Patching Plugins_x64.cfg...
+:: We never blindly append: that risks producing
+::   Plugin=RenderSystem_Direct3D11Plugin=KenshiMP.Core
+:: on a single line if the file lacks a trailing newline.
+:: PowerShell rewrites the file with consistent CRLF line endings.
+echo  [3/7] Patching Plugins_x64.cfg...
 
-findstr /C:"Plugin=KenshiMP.Core" "%KENSHI_DIR%\Plugins_x64.cfg" >nul 2>&1
+findstr /B /C:"Plugin=KenshiMP.Core" "%KENSHI_DIR%\Plugins_x64.cfg" >nul 2>&1
 if errorlevel 1 (
-    echo Plugin=KenshiMP.Core>> "%KENSHI_DIR%\Plugins_x64.cfg"
+    powershell -NoProfile -ExecutionPolicy Bypass -Command "$p = Join-Path '%KENSHI_DIR%' 'Plugins_x64.cfg'; $lines = @(); if (Test-Path $p) { $lines = @(Get-Content -LiteralPath $p) }; $lines = @($lines | Where-Object { $_ -ne 'Plugin=KenshiMP.Core' }); $lines += 'Plugin=KenshiMP.Core'; Set-Content -LiteralPath $p -Value $lines -Encoding ASCII"
+    if errorlevel 1 (
+        echo  [ERROR] Failed to patch Plugins_x64.cfg. Try running as Administrator.
+        pause
+        exit /b 1
+    )
     echo         Added KenshiMP.Core plugin entry
 ) else (
     echo         Plugin entry already exists
 )
 
-:: ── Patch Main Menu Layout ──
-echo  [4/5] Patching main menu layout...
+:: ── Install Main Menu Layout (always overwrite with pre-patched copy) ──
+:: The previous version used a fragile in-place PowerShell regex insertion
+:: that often produced malformed XML on user systems. The shipped
+:: Kenshi_MainMenu.layout is a vanilla layout with the MULTIPLAYER button
+:: already in place — overwriting is reliable across Kenshi versions and
+:: locales because the layout file has not changed since FCS 1.0.
+:: The original is preserved in KenshiMP_backup\.
+echo  [4/7] Installing main menu layout...
 
-findstr /C:"MultiplayerButton" "%KENSHI_DIR%\data\gui\layout\Kenshi_MainMenu.layout" >nul 2>&1
+copy /Y "%~dp0Kenshi_MainMenu.layout" "%KENSHI_DIR%\data\gui\layout\Kenshi_MainMenu.layout" >nul
 if errorlevel 1 (
-    echo         Adding MULTIPLAYER button to main menu...
-
-    :: We need to insert the button before the OPTIONS button.
-    :: The OPTIONS button has name="OptionsButton".
-    :: We'll use PowerShell for reliable XML insertion.
-
-    powershell -NoProfile -ExecutionPolicy Bypass -Command ^
-        "$file = '%KENSHI_DIR%\data\gui\layout\Kenshi_MainMenu.layout';" ^
-        "$content = Get-Content $file -Raw;" ^
-        "$mpButton = @'" ^
-"            <Widget type=\""Button\"" skin=\""Kenshi_Button1\"" position_real=\""0.260417 0.582407 0.15625 0.0638889\"" name=\""MultiplayerButton\"">`n" ^
-"                <Property key=\""Caption\"" value=\""MULTIPLAYER\""/>`n" ^
-"                <Property key=\""FontName\"" value=\""Kenshi_PaintedTextFont_Large\""/>`n" ^
-"            </Widget>`n" ^
-"'@;" ^
-        "if ($content -match 'OptionsButton') {" ^
-        "  $optLine = '            <Widget type=\"\"Button\"\" skin=\"\"Kenshi_Button1\"\".*name=\"\"OptionsButton\"\"';" ^
-        "  $content = $content -replace '(?m)(^\s*<Widget[^>]+name=\"\"OptionsButton\"\")', ($mpButton + \"`n`$1\");" ^
-        "  Set-Content $file $content -NoNewline;" ^
-        "  Write-Host '        MULTIPLAYER button added';" ^
-        "} else {" ^
-        "  Write-Host '        [WARNING] Could not find OptionsButton anchor';" ^
-        "}"
-
-    if errorlevel 1 (
-        echo         [WARNING] Auto-patch failed. Copying pre-patched layout...
-        if exist "%~dp0Kenshi_MainMenu.layout" (
-            copy /Y "%~dp0Kenshi_MainMenu.layout" "%KENSHI_DIR%\data\gui\layout\Kenshi_MainMenu.layout" >nul
-            echo         Copied pre-patched Kenshi_MainMenu.layout
-        )
-    )
-) else (
-    echo         MULTIPLAYER button already present
-)
-
-:: ── Copy Multiplayer Layouts ──
-echo  [5/6] Installing multiplayer layouts...
-
-if exist "%~dp0Kenshi_MultiplayerPanel.layout" (
-    copy /Y "%~dp0Kenshi_MultiplayerPanel.layout" "%KENSHI_DIR%\data\gui\layout\Kenshi_MultiplayerPanel.layout" >nul
-    echo         Copied Kenshi_MultiplayerPanel.layout
-) else (
-    echo  [ERROR] Kenshi_MultiplayerPanel.layout not found in installer folder!
+    echo  [ERROR] Failed to install Kenshi_MainMenu.layout.
     pause
     exit /b 1
 )
+echo         Installed Kenshi_MainMenu.layout (with MULTIPLAYER button)
+
+:: ── Copy Multiplayer Layouts ──
+echo  [5/7] Installing multiplayer layouts...
+
+copy /Y "%~dp0Kenshi_MultiplayerPanel.layout" "%KENSHI_DIR%\data\gui\layout\Kenshi_MultiplayerPanel.layout" >nul
+if errorlevel 1 (
+    echo  [ERROR] Failed to install Kenshi_MultiplayerPanel.layout.
+    pause
+    exit /b 1
+)
+echo         Copied Kenshi_MultiplayerPanel.layout
 
 if exist "%~dp0Kenshi_MultiplayerHUD.layout" (
     copy /Y "%~dp0Kenshi_MultiplayerHUD.layout" "%KENSHI_DIR%\data\gui\layout\Kenshi_MultiplayerHUD.layout" >nul
@@ -188,21 +199,17 @@ echo  [6/7] Installing kenshi-online.mod...
 if exist "%~dp0kenshi-online.mod" (
     :: Copy to data/ (always loaded by the game engine)
     copy /Y "%~dp0kenshi-online.mod" "%KENSHI_DIR%\data\kenshi-online.mod" >nul
-    echo         Copied kenshi-online.mod to data/
+    echo         Copied kenshi-online.mod to data\
 
     :: Also copy to mods/kenshi-online/ (standard mod location)
     if not exist "%KENSHI_DIR%\mods\kenshi-online" mkdir "%KENSHI_DIR%\mods\kenshi-online"
     copy /Y "%~dp0kenshi-online.mod" "%KENSHI_DIR%\mods\kenshi-online\kenshi-online.mod" >nul
-    echo         Copied kenshi-online.mod to mods/
+    echo         Copied kenshi-online.mod to mods\
 
-    :: Add to __mods.list if not present
-    findstr /C:"kenshi-online" "%KENSHI_DIR%\data\__mods.list" >nul 2>&1
-    if errorlevel 1 (
-        echo kenshi-online>> "%KENSHI_DIR%\data\__mods.list"
-        echo         Added kenshi-online to mod load list
-    ) else (
-        echo         kenshi-online already in mod load list
-    )
+    :: Add to __mods.list if not present, normalising line endings via PowerShell.
+    if not exist "%KENSHI_DIR%\data\__mods.list" type nul > "%KENSHI_DIR%\data\__mods.list"
+    powershell -NoProfile -ExecutionPolicy Bypass -Command "$p = Join-Path '%KENSHI_DIR%' 'data\__mods.list'; $lines = @(); if (Test-Path $p) { $lines = @(Get-Content -LiteralPath $p) }; $lines = @($lines | Where-Object { $_ -ne 'kenshi-online' -and $_ -ne '' }); $lines += 'kenshi-online'; Set-Content -LiteralPath $p -Value $lines -Encoding ASCII"
+    echo         Registered kenshi-online in mod load list
 ) else (
     echo         [INFO] kenshi-online.mod not in package (mod template spawning disabled)
 )

--- a/dist/uninstall.bat
+++ b/dist/uninstall.bat
@@ -155,3 +155,4 @@ echo   Your game is back to vanilla.
 echo  ============================================
 echo.
 pause
+exit /b 0

--- a/dist/uninstall.bat
+++ b/dist/uninstall.bat
@@ -1,116 +1,229 @@
 @echo off
-setlocal enabledelayedexpansion
+setlocal EnableExtensions DisableDelayedExpansion
 title KenshiMP Uninstaller
 color 0C
 
+set "EXIT_CODE=0"
+set "QUIET=0"
+if /I "%~2"=="/quiet" set "QUIET=1"
+
 echo.
 echo  ============================================
-echo   KenshiMP - Uninstaller
+echo   KenshiMP - Safe Windows Uninstaller
 echo  ============================================
 echo.
 
-:: ── Auto-detect Kenshi directory ──
-set "KENSHI_DIR="
+set "KENSHI_DIR=%~1"
+if defined KENSHI_DIR goto :validate_kenshi
 
-if exist "%~dp0kenshi_x64.exe" (
-    set "KENSHI_DIR=%~dp0"
-    goto :found
+if exist "%~dp0kenshi_x64.exe" set "KENSHI_DIR=%~dp0"
+if defined KENSHI_DIR goto :validate_kenshi
+if exist "%~dp0..\kenshi_x64.exe" set "KENSHI_DIR=%~dp0.."
+if defined KENSHI_DIR goto :validate_kenshi
+if exist "C:\Program Files (x86)\Steam\steamapps\common\Kenshi\kenshi_x64.exe" set "KENSHI_DIR=C:\Program Files (x86)\Steam\steamapps\common\Kenshi"
+if defined KENSHI_DIR goto :validate_kenshi
+if exist "C:\GOG Games\Kenshi\kenshi_x64.exe" set "KENSHI_DIR=C:\GOG Games\Kenshi"
+if defined KENSHI_DIR goto :validate_kenshi
+
+if "%QUIET%"=="1" (
+    echo  [ERROR] Kenshi was not found and interactive prompting is disabled.
+    goto :invalid_kenshi
 )
-if exist "%~dp0..\kenshi_x64.exe" (
-    set "KENSHI_DIR=%~dp0..\"
-    goto :found
-)
-set "STEAM_KENSHI=C:\Program Files (x86)\Steam\steamapps\common\Kenshi"
-if exist "%STEAM_KENSHI%\kenshi_x64.exe" (
-    set "KENSHI_DIR=%STEAM_KENSHI%"
-    goto :found
-)
-echo  Could not find Kenshi. Enter path:
+
+echo  Kenshi could not be auto-detected.
+echo  Enter the folder containing kenshi_x64.exe.
 set /p "KENSHI_DIR=Path: "
+
+:validate_kenshi
+if not defined KENSHI_DIR goto :invalid_kenshi
+for %%I in ("%KENSHI_DIR%") do set "KENSHI_DIR=%%~fI"
 if not exist "%KENSHI_DIR%\kenshi_x64.exe" (
-    echo  [ERROR] kenshi_x64.exe not found.
-    pause
-    exit /b 1
+    echo  [ERROR] kenshi_x64.exe was not found in:
+    echo          "%KENSHI_DIR%"
+    goto :invalid_kenshi
 )
 
-:found
-if "%KENSHI_DIR:~-1%"=="\" set "KENSHI_DIR=%KENSHI_DIR:~0,-1%"
-echo  Found Kenshi at: %KENSHI_DIR%
+echo  Found Kenshi at: "%KENSHI_DIR%"
 echo.
 
-:: Check if running
 tasklist /FI "IMAGENAME eq kenshi_x64.exe" 2>NUL | find /I "kenshi_x64.exe" >NUL
-if %errorlevel% equ 0 (
-    echo  [WARNING] Kenshi is running. Close it first.
-    pause
-    exit /b 1
+if not errorlevel 1 (
+    echo  [ERROR] Kenshi is running. Close it before uninstalling.
+    set "EXIT_CODE=3"
+    goto :finish
 )
 
-set "BACKUP_DIR=%KENSHI_DIR%\KenshiMP_backup"
-
-echo  Removing KenshiMP...
-echo.
-
-:: Remove DLL
-if exist "%KENSHI_DIR%\KenshiMP.Core.dll" (
-    del /F "%KENSHI_DIR%\KenshiMP.Core.dll"
-    echo  [OK] Removed KenshiMP.Core.dll
+set "STATE_DIR=%KENSHI_DIR%\.KenshiMP-install-state"
+if not exist "%STATE_DIR%" (
+    echo  [OK] No managed KenshiMP installation was found.
+    echo       Nothing was removed. This is safe on repeated runs.
+    set "EXIT_CODE=0"
+    goto :finish
 )
+if not exist "%STATE_DIR%\installed.marker" goto :unsafe_state
+findstr /X /C:"KenshiMP managed installation v1" "%STATE_DIR%\installed.marker" >NUL 2>&1
+if errorlevel 1 goto :unsafe_state
+call :validate_state
+if errorlevel 1 goto :unsafe_state
 
-:: Remove multiplayer panel layout
-if exist "%KENSHI_DIR%\data\gui\layout\Kenshi_MultiplayerPanel.layout" (
-    del /F "%KENSHI_DIR%\data\gui\layout\Kenshi_MultiplayerPanel.layout"
-    echo  [OK] Removed Kenshi_MultiplayerPanel.layout
-)
+call :probe_directory "%KENSHI_DIR%"
+if errorlevel 1 goto :permission_error
+call :probe_directory "%KENSHI_DIR%\data"
+if errorlevel 1 goto :permission_error
+call :probe_directory "%KENSHI_DIR%\data\gui\layout"
+if errorlevel 1 goto :permission_error
+call :probe_file "%KENSHI_DIR%\KenshiMP.Core.dll"
+if errorlevel 1 goto :permission_error
+call :probe_file "%KENSHI_DIR%\KenshiMP.Server.exe"
+if errorlevel 1 goto :permission_error
+call :probe_file "%KENSHI_DIR%\server.json"
+if errorlevel 1 goto :permission_error
+call :probe_file "%KENSHI_DIR%\Plugins_x64.cfg"
+if errorlevel 1 goto :permission_error
+call :probe_file "%KENSHI_DIR%\data\gui\layout\Kenshi_MainMenu.layout"
+if errorlevel 1 goto :permission_error
+call :probe_file "%KENSHI_DIR%\data\gui\layout\Kenshi_MultiplayerPanel.layout"
+if errorlevel 1 goto :permission_error
+call :probe_file "%KENSHI_DIR%\data\gui\layout\Kenshi_MultiplayerHUD.layout"
+if errorlevel 1 goto :permission_error
+call :probe_file "%KENSHI_DIR%\data\kenshi-online.mod"
+if errorlevel 1 goto :permission_error
+call :probe_file "%KENSHI_DIR%\mods\kenshi-online\kenshi-online.mod"
+if errorlevel 1 goto :permission_error
+call :probe_file "%KENSHI_DIR%\data\__mods.list"
+if errorlevel 1 goto :permission_error
 
-:: Remove server
-if exist "%KENSHI_DIR%\KenshiMP.Server.exe" (
-    del /F "%KENSHI_DIR%\KenshiMP.Server.exe"
-    echo  [OK] Removed KenshiMP.Server.exe
-)
+echo  Restoring files recorded by the KenshiMP installer...
+call :restore_original "%KENSHI_DIR%\KenshiMP.Core.dll" "core"
+if errorlevel 1 goto :restore_failed
+call :restore_original "%KENSHI_DIR%\KenshiMP.Server.exe" "server"
+if errorlevel 1 goto :restore_failed
+call :restore_original "%KENSHI_DIR%\server.json" "server-config"
+if errorlevel 1 goto :restore_failed
+call :restore_original "%KENSHI_DIR%\Plugins_x64.cfg" "plugins-config"
+if errorlevel 1 goto :restore_failed
+call :restore_original "%KENSHI_DIR%\data\gui\layout\Kenshi_MainMenu.layout" "main-menu"
+if errorlevel 1 goto :restore_failed
+call :restore_original "%KENSHI_DIR%\data\gui\layout\Kenshi_MultiplayerPanel.layout" "panel-layout"
+if errorlevel 1 goto :restore_failed
+call :restore_original "%KENSHI_DIR%\data\gui\layout\Kenshi_MultiplayerHUD.layout" "hud-layout"
+if errorlevel 1 goto :restore_failed
+call :restore_original "%KENSHI_DIR%\data\kenshi-online.mod" "data-mod"
+if errorlevel 1 goto :restore_failed
+call :restore_original "%KENSHI_DIR%\mods\kenshi-online\kenshi-online.mod" "folder-mod"
+if errorlevel 1 goto :restore_failed
+call :restore_original "%KENSHI_DIR%\data\__mods.list" "mods-list"
+if errorlevel 1 goto :restore_failed
 
-:: Remove multiplayer mod
-if exist "%KENSHI_DIR%\data\kenshi-online.mod" (
-    del /F "%KENSHI_DIR%\data\kenshi-online.mod"
-    echo  [OK] Removed data\kenshi-online.mod
-)
 if exist "%KENSHI_DIR%\mods\kenshi-online" (
-    rmdir /S /Q "%KENSHI_DIR%\mods\kenshi-online"
-    echo  [OK] Removed mods\kenshi-online\
-)
-
-:: Restore backups
-if exist "%BACKUP_DIR%\Plugins_x64.cfg.bak" (
-    copy /Y "%BACKUP_DIR%\Plugins_x64.cfg.bak" "%KENSHI_DIR%\Plugins_x64.cfg" >nul
-    echo  [OK] Restored original Plugins_x64.cfg
-)
-
-if exist "%BACKUP_DIR%\Kenshi_MainMenu.layout.bak" (
-    copy /Y "%BACKUP_DIR%\Kenshi_MainMenu.layout.bak" "%KENSHI_DIR%\data\gui\layout\Kenshi_MainMenu.layout" >nul
-    echo  [OK] Restored original Kenshi_MainMenu.layout
-)
-
-:: Clean up backup dir
-if exist "%BACKUP_DIR%" (
-    rmdir /S /Q "%BACKUP_DIR%" 2>nul
-    echo  [OK] Removed backup folder
-)
-
-:: Remove config
-set "CONFIG_DIR=%APPDATA%\KenshiMP"
-if exist "%CONFIG_DIR%" (
-    echo.
-    set /p "DELCONFIG=Delete KenshiMP config (%CONFIG_DIR%)? [y/N]: "
-    if /i "!DELCONFIG!"=="y" (
-        rmdir /S /Q "%CONFIG_DIR%"
-        echo  [OK] Removed config folder
+    rmdir "%KENSHI_DIR%\mods\kenshi-online" >NUL 2>&1
+    if exist "%KENSHI_DIR%\mods\kenshi-online" (
+        echo  [INFO] Preserved non-package files in mods\kenshi-online.
     )
 )
 
+call :remove_state_dir
+if exist "%STATE_DIR%" goto :restore_failed
+
 echo.
-echo  ============================================
-echo   KenshiMP has been uninstalled.
-echo   Your game is back to vanilla.
-echo  ============================================
+echo  [OK] KenshiMP was uninstalled. Original files were restored.
+set "EXIT_CODE=0"
+goto :finish
+
+:invalid_kenshi
+set "EXIT_CODE=1"
+goto :finish
+
+:permission_error
+echo  [ERROR] Kenshi files are not writable.
+echo          Run this uninstaller with permission to modify the Kenshi directory.
+set "EXIT_CODE=3"
+goto :finish
+
+:unsafe_state
+echo  [ERROR] KenshiMP installer state is incomplete or unrecognized:
+echo          "%STATE_DIR%"
+echo          Nothing was removed. Inspect or move the state directory.
+set "EXIT_CODE=4"
+goto :finish
+
+:restore_failed
+echo  [ERROR] Uninstall could not restore every recorded file.
+echo          Installer state was preserved at:
+echo          "%STATE_DIR%"
+echo          Resolve the reported filesystem problem, then run uninstall again.
+set "EXIT_CODE=4"
+goto :finish
+
+:probe_directory
+set "PROBE_FILE=%~1\.kenshimp-write-test-%RANDOM%-%RANDOM%.tmp"
+>"%PROBE_FILE%" echo write-test
+if not exist "%PROBE_FILE%" exit /b 1
+del /F /Q "%PROBE_FILE%" >NUL 2>&1
+if exist "%PROBE_FILE%" exit /b 1
+exit /b 0
+
+:probe_file
+if not exist "%~1" exit /b 0
+set "KMP_PROBE_FILE=%~1"
+powershell -NoProfile -ExecutionPolicy Bypass -Command "try { $stream = [IO.File]::Open($env:KMP_PROBE_FILE, 'Open', 'Write', 'ReadWrite'); $stream.Dispose(); exit 0 } catch { exit 1 }" >NUL 2>&1
+exit /b %ERRORLEVEL%
+
+:restore_original
+if exist "%STATE_DIR%\%~2.restore" (
+    if not exist "%STATE_DIR%\%~2.bak" (
+        echo  [ERROR] Missing backup for %~2.
+        exit /b 1
+    )
+    copy /B /Y "%STATE_DIR%\%~2.bak" "%~1" >NUL 2>&1
+    if errorlevel 1 (
+        echo  [ERROR] Could not restore: "%~1"
+        exit /b 1
+    )
+    echo  [OK] Restored "%~1"
+    exit /b 0
+)
+if exist "%STATE_DIR%\%~2.remove" (
+    if exist "%~1" del /F /Q "%~1" >NUL 2>&1
+    if exist "%~1" (
+        echo  [ERROR] Could not remove: "%~1"
+        exit /b 1
+    )
+    echo  [OK] Removed package-owned "%~1"
+    exit /b 0
+)
+echo  [ERROR] Installer state is incomplete for %~2.
+exit /b 1
+
+:validate_state
+for %%K in (core server server-config plugins-config main-menu panel-layout hud-layout data-mod folder-mod mods-list) do (
+    call :validate_state_entry "%%K"
+    if errorlevel 1 exit /b 1
+)
+exit /b 0
+
+:validate_state_entry
+if exist "%STATE_DIR%\%~1.restore" (
+    if exist "%STATE_DIR%\%~1.remove" exit /b 1
+    if not exist "%STATE_DIR%\%~1.bak" exit /b 1
+    exit /b 0
+)
+if exist "%STATE_DIR%\%~1.remove" exit /b 0
+exit /b 1
+
+:remove_state_dir
+for %%K in (core server server-config plugins-config main-menu panel-layout hud-layout data-mod folder-mod mods-list) do (
+    if exist "%STATE_DIR%\%%K.bak" del /F /Q "%STATE_DIR%\%%K.bak" >NUL 2>&1
+    if exist "%STATE_DIR%\%%K.restore" del /F /Q "%STATE_DIR%\%%K.restore" >NUL 2>&1
+    if exist "%STATE_DIR%\%%K.remove" del /F /Q "%STATE_DIR%\%%K.remove" >NUL 2>&1
+)
+if exist "%STATE_DIR%\installed.marker" del /F /Q "%STATE_DIR%\installed.marker" >NUL 2>&1
+if exist "%STATE_DIR%\transaction.marker" del /F /Q "%STATE_DIR%\transaction.marker" >NUL 2>&1
+rmdir "%STATE_DIR%" >NUL 2>&1
+exit /b 0
+
+:finish
 echo.
-pause
+if not "%EXIT_CODE%"=="0" echo  Uninstaller exit code: %EXIT_CODE%
+if "%QUIET%"=="0" pause
+exit /b %EXIT_CODE%

--- a/dist/uninstall.bat
+++ b/dist/uninstall.bat
@@ -25,6 +25,11 @@ if exist "%STEAM_KENSHI%\kenshi_x64.exe" (
     set "KENSHI_DIR=%STEAM_KENSHI%"
     goto :found
 )
+set "GOG_KENSHI=C:\GOG Games\Kenshi"
+if exist "%GOG_KENSHI%\kenshi_x64.exe" (
+    set "KENSHI_DIR=%GOG_KENSHI%"
+    goto :found
+)
 echo  Could not find Kenshi. Enter path:
 set /p "KENSHI_DIR=Path: "
 if not exist "%KENSHI_DIR%\kenshi_x64.exe" (
@@ -51,6 +56,23 @@ set "BACKUP_DIR=%KENSHI_DIR%\KenshiMP_backup"
 echo  Removing KenshiMP...
 echo.
 
+:: ── Always strip the Plugin entry from Plugins_x64.cfg ──
+:: This is the critical step that ensures Kenshi still launches if the user
+:: has no backup or has already restored their config manually.
+:: If we only removed KenshiMP.Core.dll without removing the plugin line,
+:: Ogre would fail to load the (now missing) plugin and the game would not
+:: start — this was issue #65 "Game won't open after uninstalling".
+if exist "%KENSHI_DIR%\Plugins_x64.cfg" (
+    powershell -NoProfile -ExecutionPolicy Bypass -Command "$p = Join-Path '%KENSHI_DIR%' 'Plugins_x64.cfg'; if (Test-Path $p) { $lines = @(Get-Content -LiteralPath $p) | Where-Object { $_ -ne 'Plugin=KenshiMP.Core' }; Set-Content -LiteralPath $p -Value $lines -Encoding ASCII }"
+    echo  [OK] Removed Plugin=KenshiMP.Core from Plugins_x64.cfg
+)
+
+:: ── Always strip the mod entry from __mods.list ──
+if exist "%KENSHI_DIR%\data\__mods.list" (
+    powershell -NoProfile -ExecutionPolicy Bypass -Command "$p = Join-Path '%KENSHI_DIR%' 'data\__mods.list'; if (Test-Path $p) { $lines = @(Get-Content -LiteralPath $p) | Where-Object { $_ -ne 'kenshi-online' }; Set-Content -LiteralPath $p -Value $lines -Encoding ASCII }"
+    echo  [OK] Removed kenshi-online from __mods.list
+)
+
 :: Remove DLL
 if exist "%KENSHI_DIR%\KenshiMP.Core.dll" (
     del /F "%KENSHI_DIR%\KenshiMP.Core.dll"
@@ -61,6 +83,11 @@ if exist "%KENSHI_DIR%\KenshiMP.Core.dll" (
 if exist "%KENSHI_DIR%\data\gui\layout\Kenshi_MultiplayerPanel.layout" (
     del /F "%KENSHI_DIR%\data\gui\layout\Kenshi_MultiplayerPanel.layout"
     echo  [OK] Removed Kenshi_MultiplayerPanel.layout
+)
+
+if exist "%KENSHI_DIR%\data\gui\layout\Kenshi_MultiplayerHUD.layout" (
+    del /F "%KENSHI_DIR%\data\gui\layout\Kenshi_MultiplayerHUD.layout"
+    echo  [OK] Removed Kenshi_MultiplayerHUD.layout
 )
 
 :: Remove server
@@ -79,7 +106,9 @@ if exist "%KENSHI_DIR%\mods\kenshi-online" (
     echo  [OK] Removed mods\kenshi-online\
 )
 
-:: Restore backups
+:: Restore backups (in addition to the stripping above, this restores any
+:: other modifications the installer might have made and gives the user a
+:: byte-identical copy of their original config).
 if exist "%BACKUP_DIR%\Plugins_x64.cfg.bak" (
     copy /Y "%BACKUP_DIR%\Plugins_x64.cfg.bak" "%KENSHI_DIR%\Plugins_x64.cfg" >nul
     echo  [OK] Restored original Plugins_x64.cfg
@@ -88,6 +117,18 @@ if exist "%BACKUP_DIR%\Plugins_x64.cfg.bak" (
 if exist "%BACKUP_DIR%\Kenshi_MainMenu.layout.bak" (
     copy /Y "%BACKUP_DIR%\Kenshi_MainMenu.layout.bak" "%KENSHI_DIR%\data\gui\layout\Kenshi_MainMenu.layout" >nul
     echo  [OK] Restored original Kenshi_MainMenu.layout
+) else (
+    :: No backup — strip the MultiplayerButton from the layout so the game
+    :: doesn't render a dead button after uninstall.
+    if exist "%KENSHI_DIR%\data\gui\layout\Kenshi_MainMenu.layout" (
+        powershell -NoProfile -ExecutionPolicy Bypass -Command "$p = Join-Path '%KENSHI_DIR%' 'data\gui\layout\Kenshi_MainMenu.layout'; if (Test-Path $p) { $c = Get-Content -LiteralPath $p -Raw; $c = [System.Text.RegularExpressions.Regex]::Replace($c, '(?s)\s*<Widget[^>]*name=""MultiplayerButton""[^>]*>.*?</Widget>', ''); Set-Content -LiteralPath $p -Value $c -NoNewline -Encoding UTF8 }"
+        echo  [OK] Stripped MULTIPLAYER button from Kenshi_MainMenu.layout
+    )
+)
+
+if exist "%BACKUP_DIR%\__mods.list.bak" (
+    copy /Y "%BACKUP_DIR%\__mods.list.bak" "%KENSHI_DIR%\data\__mods.list" >nul
+    echo  [OK] Restored original __mods.list
 )
 
 :: Clean up backup dir

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -48,13 +48,17 @@ This document covers CMake configuration, dependencies, build targets, project d
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/The404Studios/Kenshi-Online.git
+git clone --recursive https://github.com/The404Studios/Kenshi-Online.git
 cd Kenshi-Online
 ```
 
-### 2. Initialize Submodules (if present)
+### 2. Initialize Submodules
 
-All dependencies are currently included in `lib/` directory. No separate submodule initialization needed.
+Third-party dependencies are pinned Git submodules in `lib/`. If the repository was cloned without `--recursive`, initialize them before configuring CMake:
+
+```bash
+git submodule update --init --recursive
+```
 
 ### 3. Generate Build Files
 
@@ -98,7 +102,7 @@ All third-party libraries are located in `lib/` and built automatically via CMak
 
 ### 1. ENet (Networking)
 
-- **Version:** Latest from https://github.com/lsalzman/enet
+- **Version:** Pinned commit `8be2368a8001f28db44e81d5939de5e613025023` from https://github.com/lsalzman/enet
 - **Purpose:** Reliable UDP networking library for client-server communication
 - **Build Type:** Static library (`enet.lib`)
 - **CMake Target:** `enet`
@@ -115,7 +119,7 @@ target_include_directories(enet PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/lib/enet/incl
 
 ### 2. MinHook (Function Hooking)
 
-- **Version:** Latest from https://github.com/TsudaKageyu/minhook
+- **Version:** Pinned commit `1e9ad1eb42db11bfcb65461f687c656612d1b555` from https://github.com/TsudaKageyu/minhook
 - **Purpose:** x64 function hooking via trampoline technique
 - **Build Type:** Static library (`minhook.lib`)
 - **CMake Target:** `minhook`
@@ -131,7 +135,7 @@ add_subdirectory(lib/minhook)
 
 ### 3. spdlog (Logging)
 
-- **Version:** Latest from https://github.com/gabime/spdlog
+- **Version:** Pinned commit `48bcf39a661a13be22666ac64db8a7f886f2637e` from https://github.com/gabime/spdlog
 - **Purpose:** Fast C++ logging library
 - **Build Type:** Header-only mode
 - **CMake Target:** `spdlog::spdlog`
@@ -148,7 +152,7 @@ add_subdirectory(lib/spdlog EXCLUDE_FROM_ALL)
 
 ### 4. nlohmann/json (JSON Parsing)
 
-- **Version:** Latest from https://github.com/nlohmann/json
+- **Version:** Pinned commit `9cca280a4d0ccf0c08f47a99aa71d1b0e52f8d03` from https://github.com/nlohmann/json
 - **Purpose:** JSON serialization/deserialization
 - **Build Type:** Header-only
 - **CMake Target:** `nlohmann_json::nlohmann_json`
@@ -166,6 +170,7 @@ add_subdirectory(lib/json EXCLUDE_FROM_ALL)
 ### 5. imgui (Optional, currently unused)
 
 - **Location:** `lib/imgui/`
+- **Version:** Pinned commit `dbb5eeaadffb6a3ba6a60de1290312e5802dba5a` from https://github.com/ocornut/imgui
 - **Status:** Included but not currently linked to any project
 - **Note:** Native MyGUI overlay is used instead for in-game UI
 
@@ -786,13 +791,11 @@ target_link_libraries(KenshiMP.Scanner PUBLIC
 MinHook: Could not find hde64.c
 ```
 
-**Cause:** Incomplete MinHook submodule.
+**Cause:** MinHook submodule is not initialized or is incomplete.
 
 **Fix:**
 ```bash
-cd lib/minhook
-git pull origin master
-cd ../..
+git submodule update --init --checkout lib/minhook
 cmake --build build --target minhook --config Release
 ```
 
@@ -812,9 +815,8 @@ error: nlohmann/json.hpp: No such file or directory
 # Check if lib/json exists
 ls lib/json/
 
-# If empty, reclone
-rm -rf lib/json
-git clone https://github.com/nlohmann/json.git lib/json
+# If empty, restore the pinned submodule revision
+git submodule update --init --checkout lib/json
 
 # Rebuild
 cmake --build build --config Release

--- a/docs/INSTALLER-VALIDATION.md
+++ b/docs/INSTALLER-VALIDATION.md
@@ -1,0 +1,57 @@
+# Windows installer validation
+
+The release `install.bat` and `uninstall.bat` accept an optional Kenshi path as
+their first argument. Pass `/quiet` as the second argument to suppress `pause`
+and interactive path prompts during validation:
+
+```powershell
+cmd /d /c "install.bat ""C:\Games\Kenshi Test"" /quiet"
+cmd /d /c "uninstall.bat ""C:\Games\Kenshi Test"" /quiet"
+```
+
+Exit codes are stable and intended for diagnostics:
+
+| Code | Meaning |
+| ---: | --- |
+| `0` | The requested operation completed, including an already-uninstalled state. |
+| `1` | The Kenshi path is missing or invalid. |
+| `2` | The extracted release package is incomplete or invalid. |
+| `3` | Kenshi is running or required locations are not writable. |
+| `4` | An install, verification, or restore operation failed. |
+
+## Isolated validation procedure
+
+Never test against a real Kenshi installation when validating destructive error
+paths. Instead, extract `KenshiMP-Install.zip` into a temporary package directory
+and create a fake Kenshi tree containing:
+
+```text
+kenshi_x64.exe
+Plugins_x64.cfg
+data\__mods.list
+data\gui\layout\Kenshi_MainMenu.layout
+mods\
+```
+
+Record hashes of the original config, mod list, and main-menu layout. Run these
+cases and check both the exit code and resulting filesystem state:
+
+1. Install from a package directory whose path contains spaces; expect `0`.
+2. Install again; expect `0`, one plugin line, one mod-list line, and unchanged
+   original backups.
+3. Uninstall; expect `0`, restored original hashes, and removal of only files
+   installed by KenshiMP.
+4. Uninstall again; expect `0` and no filesystem changes.
+5. Pass a directory without `kenshi_x64.exe`; expect `1` and no changes.
+6. Remove or empty one required package input; expect `2` before any Kenshi file
+   is changed.
+7. Deny write access to the fake Kenshi tree; expect `3` and no installation.
+8. Add an unrelated file under `mods\kenshi-online`, then uninstall. The unrelated
+   file and directory must remain.
+9. Force a destination copy or restore failure. Expect `4`, an explicit error,
+   and preserved `.KenshiMP-install-state` diagnostics. A failed first install
+   must restore the original files.
+
+The state directory belongs to the hardened installer. The uninstaller performs
+no deletion when its `installed.marker` is absent, which prevents it from
+guessing ownership of files from older or unrelated installations.

--- a/tools/package-release.ps1
+++ b/tools/package-release.ps1
@@ -1,0 +1,263 @@
+[CmdletBinding()]
+param(
+    [string]$OutputDirectory
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot ".."))
+$buildRoot = Join-Path $repoRoot "build"
+$releaseRoot = Join-Path $buildRoot "bin\Release"
+
+if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+    $OutputDirectory = Join-Path $buildRoot "package"
+} elseif (-not [System.IO.Path]::IsPathRooted($OutputDirectory)) {
+    $OutputDirectory = Join-Path $repoRoot $OutputDirectory
+}
+
+$OutputDirectory = [System.IO.Path]::GetFullPath($OutputDirectory)
+$buildRootWithSeparator = $buildRoot.TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
+if (-not $OutputDirectory.StartsWith($buildRootWithSeparator, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "OutputDirectory must stay inside the build directory: $buildRoot"
+}
+
+$zipPath = Join-Path $OutputDirectory "KenshiMP-Install.zip"
+$manifestPath = Join-Path $OutputDirectory "package-manifest.txt"
+$checksumsPath = Join-Path $OutputDirectory "SHA256SUMS.txt"
+$temporaryZipPath = Join-Path $OutputDirectory ".KenshiMP-Install.zip.tmp"
+$temporaryManifestPath = Join-Path $OutputDirectory ".package-manifest.txt.tmp"
+$temporaryChecksumsPath = Join-Path $OutputDirectory ".SHA256SUMS.txt.tmp"
+
+function Write-Utf8File {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$Lines
+    )
+
+    $content = [string]::Join("`n", $Lines) + "`n"
+    $encoding = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText($Path, $content, $encoding)
+}
+
+function Get-LowercaseSha256 {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path
+    )
+
+    return (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash.ToLowerInvariant()
+}
+
+function Get-StreamSha256 {
+    param(
+        [Parameter(Mandatory = $true)]
+        [System.IO.Stream]$Stream
+    )
+
+    $sha256 = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $hash = $sha256.ComputeHash($Stream)
+        return ([System.BitConverter]::ToString($hash)).Replace("-", "").ToLowerInvariant()
+    } finally {
+        $sha256.Dispose()
+    }
+}
+
+function New-PackageInput {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Source,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ArchivePath,
+
+        [long]$MinimumSize = 1
+    )
+
+    return [pscustomobject]@{
+        Source = $Source
+        ArchivePath = $ArchivePath
+        MinimumSize = $MinimumSize
+    }
+}
+
+# Keep this list explicit and in ordinal ArchivePath order. The installer expects
+# every packaged file at the ZIP root, so layout files must not be moved into a
+# subdirectory without a separate installer change.
+$packageInputs = @(
+    (New-PackageInput "dist/JOINING.md" "JOINING.md"),
+    (New-PackageInput "build/bin/Release/KenshiMP.Core.dll" "KenshiMP.Core.dll" 65536),
+    (New-PackageInput "build/bin/Release/KenshiMP.Injector.exe" "KenshiMP.Injector.exe"),
+    (New-PackageInput "build/bin/Release/KenshiMP.Server.exe" "KenshiMP.Server.exe"),
+    (New-PackageInput "dist/Kenshi_MainMenu.layout" "Kenshi_MainMenu.layout"),
+    (New-PackageInput "dist/Kenshi_MultiplayerHUD.layout" "Kenshi_MultiplayerHUD.layout"),
+    (New-PackageInput "dist/Kenshi_MultiplayerPanel.layout" "Kenshi_MultiplayerPanel.layout"),
+    (New-PackageInput "dist/install.bat" "install.bat"),
+    (New-PackageInput "dist/kenshi-online.mod" "kenshi-online.mod"),
+    (New-PackageInput "dist/server.json" "server.json"),
+    (New-PackageInput "dist/uninstall.bat" "uninstall.bat")
+)
+
+for ($index = 1; $index -lt $packageInputs.Count; $index++) {
+    $previous = $packageInputs[$index - 1].ArchivePath
+    $current = $packageInputs[$index].ArchivePath
+    if ([System.StringComparer]::Ordinal.Compare($previous, $current) -ge 0) {
+        throw "Package inputs must remain in unique ordinal ArchivePath order: $previous, $current"
+    }
+}
+
+New-Item -ItemType Directory -Path $OutputDirectory -Force | Out-Null
+foreach ($path in @(
+    $zipPath,
+    $manifestPath,
+    $checksumsPath,
+    $temporaryZipPath,
+    $temporaryManifestPath,
+    $temporaryChecksumsPath
+)) {
+    Remove-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue
+}
+
+$cachePath = Join-Path $buildRoot "CMakeCache.txt"
+if (-not (Test-Path -LiteralPath $cachePath -PathType Leaf)) {
+    throw "Release build is not configured. Run cmake --preset x64-release first."
+}
+
+Write-Host "Building the configured Release tree before packaging..."
+Push-Location $repoRoot
+try {
+    & cmake --build build --config Release
+    if ($LASTEXITCODE -ne 0) {
+        throw "Release build failed with exit code $LASTEXITCODE."
+    }
+} finally {
+    Pop-Location
+}
+
+$validatedInputs = @()
+$repoRootWithSeparator = $repoRoot.TrimEnd('\', '/') + [System.IO.Path]::DirectorySeparatorChar
+foreach ($input in $packageInputs) {
+    $sourcePath = [System.IO.Path]::GetFullPath((Join-Path $repoRoot $input.Source))
+    if (-not $sourcePath.StartsWith($repoRootWithSeparator, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Package input resolves outside the repository: $($input.Source)"
+    }
+
+    if (-not (Test-Path -LiteralPath $sourcePath -PathType Leaf)) {
+        throw "Required package input is missing: $($input.Source)"
+    }
+
+    $file = Get-Item -LiteralPath $sourcePath
+    if ($file.Length -lt $input.MinimumSize) {
+        throw "Required package input is too small: $($input.Source) is $($file.Length) bytes; minimum is $($input.MinimumSize)."
+    }
+
+    $validatedInputs += [pscustomobject]@{
+        ArchivePath = $input.ArchivePath
+        FullPath = $sourcePath
+        Size = $file.Length
+        Sha256 = Get-LowercaseSha256 $sourcePath
+    }
+}
+
+$manifestLines = @(
+    "# KenshiMP deterministic Windows package manifest",
+    "# SHA256`tSize`tPath"
+)
+foreach ($input in $validatedInputs) {
+    $manifestLines += "$($input.Sha256)`t$($input.Size)`t$($input.ArchivePath)"
+}
+Write-Utf8File -Path $temporaryManifestPath -Lines $manifestLines
+
+Add-Type -AssemblyName System.IO.Compression
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+$fixedTimestamp = New-Object System.DateTimeOffset(1980, 1, 1, 0, 0, 0, [System.TimeSpan]::Zero)
+
+$zipStream = $null
+$archive = $null
+try {
+    $zipStream = [System.IO.File]::Open(
+        $temporaryZipPath,
+        [System.IO.FileMode]::CreateNew,
+        [System.IO.FileAccess]::Write,
+        [System.IO.FileShare]::None
+    )
+    $archive = New-Object System.IO.Compression.ZipArchive(
+        $zipStream,
+        [System.IO.Compression.ZipArchiveMode]::Create,
+        $false
+    )
+
+    foreach ($input in $validatedInputs) {
+        $entry = $archive.CreateEntry(
+            $input.ArchivePath,
+            [System.IO.Compression.CompressionLevel]::Optimal
+        )
+        $entry.LastWriteTime = $fixedTimestamp
+
+        $sourceStream = [System.IO.File]::OpenRead($input.FullPath)
+        $entryStream = $entry.Open()
+        try {
+            $sourceStream.CopyTo($entryStream)
+        } finally {
+            $entryStream.Dispose()
+            $sourceStream.Dispose()
+        }
+    }
+} finally {
+    if ($null -ne $archive) {
+        $archive.Dispose()
+    }
+    if ($null -ne $zipStream) {
+        $zipStream.Dispose()
+    }
+}
+
+$readArchive = [System.IO.Compression.ZipFile]::OpenRead($temporaryZipPath)
+try {
+    $entries = @($readArchive.Entries)
+    if ($entries.Count -ne $validatedInputs.Count) {
+        throw "ZIP entry count does not match the manifest."
+    }
+
+    for ($index = 0; $index -lt $validatedInputs.Count; $index++) {
+        $expected = $validatedInputs[$index]
+        $entry = $entries[$index]
+        if ($entry.FullName -cne $expected.ArchivePath) {
+            throw "ZIP order mismatch at entry ${index}: $($entry.FullName), expected $($expected.ArchivePath)."
+        }
+        if ($entry.Length -ne $expected.Size) {
+            throw "ZIP size mismatch for $($entry.FullName)."
+        }
+
+        $entryStream = $entry.Open()
+        try {
+            $entryHash = Get-StreamSha256 $entryStream
+        } finally {
+            $entryStream.Dispose()
+        }
+        if ($entryHash -cne $expected.Sha256) {
+            throw "ZIP SHA-256 mismatch for $($entry.FullName)."
+        }
+    }
+} finally {
+    $readArchive.Dispose()
+}
+
+$zipHash = Get-LowercaseSha256 $temporaryZipPath
+$manifestHash = Get-LowercaseSha256 $temporaryManifestPath
+Write-Utf8File -Path $temporaryChecksumsPath -Lines @(
+    "$zipHash  KenshiMP-Install.zip",
+    "$manifestHash  package-manifest.txt"
+)
+
+Move-Item -LiteralPath $temporaryZipPath -Destination $zipPath
+Move-Item -LiteralPath $temporaryManifestPath -Destination $manifestPath
+Move-Item -LiteralPath $temporaryChecksumsPath -Destination $checksumsPath
+
+Write-Host "Created deterministic Windows package outputs:"
+Get-Item -LiteralPath $zipPath, $manifestPath, $checksumsPath |
+    Select-Object FullName, Length


### PR DESCRIPTION
## Summary

This PR integrates the currently validated hardening work from the `Dedstate/Kenshi-Online` fork:

- restores missing CMake build-graph sources and clean-checkout dependency recovery;
- adds Windows CI and deterministic release packaging;
- combines Windows installer safety/rollback hardening with the Woki patch set;
- hardens client connect/disconnect/send paths, packet dispatch, pointer access, crash breadcrumbs, and player-template fallback for players 3–16;
- updates the README to the current ZIP installer and connection flow (UDP port 27800).

## Source / provenance

The core/network/spawn and complementary installer changes originated from ZIP patches based on `WokiDev/Kenshi-Online`.

The imported set consists of six patch blocks plus one batch-parsing smoke-test fix:

1. installer reliability improvements;
2. send/disconnect race prevention;
3. connect/disconnect lifecycle hardening;
4. SEH guard around packet dispatch;
5. pointer-access and crash-breadcrumb hardening;
6. player-template fallback for players 3–16;
7. follow-up batch parsing and success-exit-code fix found by installer smoke testing.

Patches `0001` and `0004` were adapted to the fork's existing code. The remaining patch blocks were applied with `--recount`.

## Installer conflict resolution

The overlapping `dist/install.bat` and `dist/uninstall.bat` changes were resolved manually rather than selecting either side wholesale.

Preserved from installer hardening:

- strict package and Kenshi-directory validation;
- write-access probes;
- managed install-state markers;
- original-file backups;
- first-install rollback;
- idempotent repeated installs;
- guarded uninstall and byte-for-byte restoration;
- explicit exit codes and post-install verification.

Preserved from the Woki-derived work:

- corrected install/uninstall flow handling;
- compatibility with the multiplayer files and layout deployment;
- safer configuration updates;
- the smoke-test-discovered batch parser fix and successful exit propagation.

The result keeps the stronger transaction/rollback model while incorporating the flow and parsing fixes needed for real repeated install/uninstall runs.

## Commit breakdown

In addition to the seven Woki-derived hardening commits, this branch includes the fork's current integration work for:

- missing CMake sources;
- clean-checkout dependency recovery;
- Windows CI;
- deterministic Windows package generation;
- Windows installer hardening;
- integration merge commits;
- current installation/connection documentation.

## Validation completed

- Working tree clean after the documentation commit.
- Upstream comparison: `0 behind / 23 ahead` at PR creation.
- Final diff limited to the expected build, CI, installer, hardening, packaging, and documentation files.
- Protocol constants and protocol message structures are unchanged.
- `cmake --preset x64-release`: passed.
- Full `cmake --build build --config Release`: passed.
- All changed C++ units and final Release targets compiled and linked.
- `KenshiMP.UnitTest`: **95 passed, 0 failed**.
- Installer smoke: install twice, then uninstall: passed.
- Installer-managed configuration and layout files restored byte-for-byte.
- Deterministic package creation and package-content verification passed.
- README Markdown diff check passed.

## Validation not completed

The following still require a real Kenshi session, Windows Sandbox, or VM:

- runtime Kenshi hook/SEH behavior;
- real network sessions and disconnect races;
- actual player spawning for players 3–16;
- full host/join gameplay validation;
- compatibility across supported Kenshi/Steam/GOG installations.

The successful unit and build checks must not be interpreted as proof of those runtime behaviors.

## Risk assessment

**Risk: medium to high.** Build, packaging, and installer changes are well covered by deterministic and smoke checks. The runtime changes touch process memory, hooks, networking, and SEH boundaries, where unit tests cannot reproduce Kenshi's real executable state. The player-template fallback also needs multi-client in-game validation.

## User impact

Users get a reproducible Windows build/package path, a safer idempotent installer/uninstaller, corrected installation documentation, and defensive multiplayer behavior. The README points to the currently published fork prerelease until an equivalent upstream artifact is produced.

## Next steps before merge

1. Install the generated ZIP in a clean Windows Sandbox or VM.
2. Verify first install, repeated install, upgrade, uninstall, and rollback against real Kenshi files.
3. Run host/join tests in Kenshi with at least 2 clients.
4. Exercise disconnect/reconnect and malformed/late packet scenarios.
5. Validate real spawning for player slots 3–16.
6. Only after runtime validation, decide whether upstream should publish a new prerelease and replace the temporary fork release links in README.
